### PR TITLE
ngFocus provide

### DIFF
--- a/textAngular.js
+++ b/textAngular.js
@@ -222,8 +222,8 @@ textAngular.directive("textAngular", function($compile, $sce, $window, $document
 	return {
 		require: 'ngModel',
 		scope: {
-        ngFocus: '&'
-      },
+      ngFocus: '&'
+    },
 		restrict: "EA",
 		link: function(scope, element, attrs, ngModel) {
 			var group, groupElement, keydown, keyup, tool, toolElement; //all these vars should not be accessable outside this directive


### PR DESCRIPTION
In my project i need to show toolbar only when editor is active.
It's mean that use click to editor or focus it by tab on keyboard.

Click to editor easy to implement as ngClick by parrent element, but with ngFocus it's impossible.
