### PR TITLE
update textAngular.min.js bower install location

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Demo is available at: http://www.textangular.com
 Run `bower install textAngular` from the command line.
 Include script tags similar to the following:
 ```html
-<script src='/bower_components/textAngular/dist/textAngular-sanitize.min.js'></script>
-<script src='/bower_components/textAngular/dist/textAngular.min.js'></script>
+<script src='/bower_components/textAngular/textAngular-sanitize.min.js'></script>
+<script src='/bower_components/textAngular/textAngular.min.js'></script>
 ```
 
 **Via CDNJS:**


### PR DESCRIPTION
as of textAngular 1.2.0, there is no dist folder built by bower, and the .js files are in the root
