### PR TITLE
fixing bug caused by input element was being inserted before document is...

### DIFF
--- a/src/textAngular.js
+++ b/src/textAngular.js
@@ -31,7 +31,9 @@ See README.md or https://github.com/fraywing/textAngular/wiki for requirements a
 			}
 			globalContentEditableBlur = false;
 		}, false); // add global click handler
-		angular.element(document.body).append('<input id="textAngular-editableFix-010203040506070809" style="width:1px;height:1px;border:none;margin:0;padding:0;position:absolute; top: -10000; left: -10000;" unselectable="on" tabIndex="-1">');
+		angular.element(document).ready(function () {
+			angular.element(document.body).append(angular.element('<input id="textAngular-editableFix-010203040506070809" style="width:1px;height:1px;border:none;margin:0;padding:0;position:absolute; top: -10000; left: -10000;" unselectable="on" tabIndex="-1">'));
+		});
 	}
 	// IE version detection - http://stackoverflow.com/questions/4169160/javascript-ie-detection-why-not-use-simple-conditional-comments
 	// We need this as IE sometimes plays funny tricks with the contenteditable.


### PR DESCRIPTION
Fix bug causing `Uncaught TypeError: Cannot read property 'setSelectionRange' of null`. Input element was being inserted before document ready.
