### PR TITLE
Use unminified file in "main" in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "textAngular",
   "version": "1.2.2",
-  "main": "./src/textAngular.js",
+  "main": ["./src/textAngular.js", "./src/textAngularSetup.js"],
   "description": "A radically powerful Text-Editor/Wysiwyg editor for Angular.js",
   "keywords": [
     "editor",


### PR DESCRIPTION
[As per Bower's commands](https://github.com/bower/bower.json-spec#main).

Side note: I've been thinking of including `textAngular-sanitize.js` but it's not really mandatory. Is there any way to actually use `angular-sanitize.js` and override the usage of it? That way we can include `angular-sanitize.js` to the dependency and add the overrides to the main (or add them to `textAngular.js`).
