### PR TITLE
Use ms-pasteTextOnly to fix text pasting issues on IE11

### DIFF
--- a/src/textAngular.js
+++ b/src/textAngular.js
@@ -1053,6 +1053,9 @@ See README.md or https://github.com/fraywing/textAngular/wiki for requirements a
 									var range = $document[0].selection.createRange();
 									range.pasteHTML(text);
 								}
+								else if($window.clipboardData){
+									$document[0].execCommand('ms-pasteTextOnly');
+								}
 								else{
 									$document[0].execCommand('insertText', false, text);
 								}


### PR DESCRIPTION
Supposedly can fix #298. Pinging @anitin and @jonathansampson for help on checking this as well.

Long story short, `insertText` command is not supported (?) in IE11. Went to the documentations on MSDN on execCommand and found `ms-pasteTextOnly`. 

Works like a charm for me, but I haven't thoroughly tested the whole thing to confirm that it doesn't break support on other browsers and so on. Go ahead and review it first.
