### PR TITLE
Errors in taToolExecuteAction will not pass silently.

### DIFF
--- a/src/textAngular.js
+++ b/src/textAngular.js
@@ -1629,7 +1629,9 @@ See README.md or https://github.com/fraywing/textAngular/wiki for requirements a
 			var result;
 			try{
 				result = this.action(deferred, _editor.startAction());
-			}catch(any){}
+			}catch(exc){
+				console.error(exc);
+			}
 			if(result || result === undefined){
 				// if true or undefined is returned then the action has finished. Otherwise the deferred action will be resolved manually.
 				deferred.resolve();


### PR DESCRIPTION
This little line made tool debugging really hard - and with this little fix it gets a bit easier :)

Try debugging this:

```
taRegisterTool('setColor', {
    iconclass: 'fa fa-tint',
    tooltiptext: 'hahaha',
    action: function (deferred) {
        var container = editorScope.displayElements.popoverContainer;
        debugger;
        return this.$editor().wrapSelection('forecolor', 'red', null);
    },
});
```

The action gets executed, but first line throws and an exception and execution never gets to the debugger statement. With this fix you at least get an error message in console.
