### PR TITLE
Fixes input tag issue in webkit-focus-workaround.

### DIFF
--- a/src/textAngular.js
+++ b/src/textAngular.js
@@ -28,8 +28,11 @@ See README.md or https://github.com/fraywing/textAngular/wiki for requirements a
 				if(!isEditable){
 					document.getElementById('textAngular-editableFix-010203040506070809').setSelectionRange(0, 0); // set caret focus to an element that handles caret focus correctly.
 					curelement.focus(); // focus the wanted element.
+					if (curelement.select) {
+						curelement.select(); // use select to place cursor for input elements.
+					}
 				}
-			}	
+			}
 			globalContentEditableBlur = false;
 		}, false); // add global click handler
 		angular.element(document).ready(function () {


### PR DESCRIPTION
The focus workaround built for webkit browsers seems to be weird when the focusout was triggered by clicking  on an outer input element.

**Reproduction steps** (chrome 38) for the demo site hosted on http://textangular.com/:  

```
// create a dummy input
input = document.createElement('input');
// add it to the document
document.body.appendChild(input);
```

Now click inside the editor / type something, then click inside the created dummy input element.

**The caret disappears and if you start to type, you can enter only one character.**

Kind of a weird bug, looked up the tests, but couldn't found the right place for this. PhantomJS is webkit AFAIK, however I'm not sure how/where could I make a failing test for this. If you give me some tipps, I can try to add a failing-before/passing-after test for this fix.
