### PR TITLE
Fixing break with Google Closure

### DIFF
--- a/src/textAngular.js
+++ b/src/textAngular.js
@@ -1103,7 +1103,7 @@ angular.module('textAngular.taBind', ['textAngular.factories', 'textAngular.DOM'
 								var _new = angular.element(_defaultVal);
 								if (/^<br(|\/)>$/i.test(selection.innerHTML.trim()) && selection.parentNode.tagName.toLowerCase() === 'blockquote' && !selection.nextSibling) {
 									// if last element in blockquote and element is blank, pull element outside of blockquote.
-									$selection = angular.element(selection);
+									var $selection = angular.element(selection);
 									var _parent = $selection.parent();
 									_parent.after(_new);
 									$selection.remove();


### PR DESCRIPTION
If JS is compiled in Google Closure, this variable with break unless defined.