### PR TITLE
add .bowerrc to force deault installation folder for bower, in case...

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+    "directory": "bower_components"
+}


### PR DESCRIPTION
... textAngular is installed as a submodule of some project 

details please refer to #437 
