### PR TITLE
Added the possibility to wrap selection with any custom tag

### DIFF
--- a/src/textAngular.js
+++ b/src/textAngular.js
@@ -553,6 +553,9 @@ angular.module('textAngular.DOM', ['textAngular.factories'])
 				}else if(command.toLowerCase() === 'inserthtml'){
 					taSelection.insertHtml(options, topNode);
 					return;
+				}else if(command.toLowerCase() === 'customtags'){
+					taSelection.surroundSelection(options);
+					return;
 				}
 			}
 			try{
@@ -716,6 +719,18 @@ function($window, $document){
 			range.insertNode(frag);
 			if(lastNode){
 				api.setSelectionToElementEnd(lastNode);
+			}
+		},
+		surroundSelection: function(htmlString) {
+			var range = rangy.getSelection().getRangeAt(0);
+			var node = range.createContextualFragment(htmlString);
+
+			if (range.commonAncestorContainer.outerHTML.replace(range.commonAncestorContainer.innerHTML, '') !== htmlString) {
+				range.surroundContents(node.firstChild);
+			} else {
+				var oldInnerHTML = range.commonAncestorContainer.innerHTML;
+				angular.element(api.getSelection().container).remove();
+				api.insertHtml(oldInnerHTML);
 			}
 		}
 	};


### PR DESCRIPTION
Clicking again will remove it. Pretty much like toggling it.

Exemplary usage of this in textAngularSetup.js:

```javascript
        taRegisterTool('customBoldTag', {
            iconclass: "fa fa-bold",
            tooltiptext: taTranslations.bold.tooltip,
            action: function(){
                this.$editor().wrapSelection('customTags', '<span class="rtStrong"></span>');
            },
            activeState: function (commonElement) {
                if(commonElement) {
                    return commonElement[0].outerHTML.replace(commonElement[0].innerHTML, '') === '<span class="rtStrong"></span>';
                }
                return false;
            }
        });
```

A known Bug which I couldn't fix atm is the following: If you don't select anything, just setting the cursor inside the editor and press the customTag button it will create that empty tag, but the user now would expect to write in that tag, actually he is writing before that tag.