### PR TITLE
Update bower.json,  rangy

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "angular": "^1.2.x",
     "bootstrap": "^3.0.x",
     "font-awesome": "^4.0.x",
-    "rangy": "^1.3.0"
+    "rangy": "^1.2.3"
   },
   "devDependencies": {
     "angular-mocks": "~1.2.x",


### PR DESCRIPTION
the current stable version is at 1.2.3
when trying to bower install textAngular, I get this error:
bower rangy#^1.3.0        ENORESTARGET No tag found that was able to satisfy ^1.3.0

Additional error details:
Available versions: 1.2.3