### PR TITLE
chore: remove "rangy-official" from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,8 +5,7 @@
     "./src/textAngular.js",
     "./src/textAngular-sanitize.js",
     "./src/textAngularSetup.js",
-    "./src/textAngular.css",
-    "../rangy-official/rangy-selectionsaverestore.js"
+    "./src/textAngular.css"
   ],
   "description": "A radically powerful Text-Editor/Wysiwyg editor for Angular.js",
   "keywords": [


### PR DESCRIPTION
avoid the injection of the following line of code in index.html, for it is not needed any more:
`<script src="bower_components/rangy-official/rangy-selectionsaverestore.js"></script>`

it closes the issue #514