### PR TITLE
Updated word count and character count to use ng-bind instead of interpolation

### DIFF
--- a/src/textAngularSetup.js
+++ b/src/textAngularSetup.js
@@ -654,7 +654,7 @@ angular.module('textAngularSetup', [])
 		}
 	});
 	taRegisterTool('wordcount', {
-		display: '<div id="toolbarWC" style="display:block; min-width:100px;">Words:{{wordcount}}</div>',
+		display: '<div id="toolbarWC" style="display:block; min-width:100px;">Words: <span ng-bind="wordcount"></span></div>',
 		disabled: true,
 		wordcount: 0,
 		activeState: function(){ // this fires on keyup
@@ -674,7 +674,7 @@ angular.module('textAngularSetup', [])
 		}
 	});
 	taRegisterTool('charcount', {
-		display: '<div id="toolbarCC" style="display:block; min-width:120px;">Characters:{{charcount}}</div>',
+		display: '<div id="toolbarCC" style="display:block; min-width:120px;">Characters: <span ng-bind="charcount"></span></div>',
 		disabled: true,
 		charcount: 0,
 		activeState: function(){ // this fires on keyup


### PR DESCRIPTION
Updated word count and character count to use ng-bind instead of interpolation for the case where interpolation symbols are overridden. I ran into this issue where I am building an angular app that uses laravel for the api and to hand off views. Laravel uses {{ and }} for it's blade engine so I overrode angular's interpolation symbols which causes word and character count to not work with textAngular.

Example of my override:
ssApp.config(function interpolateConfig($interpolateProvider) {
    $interpolateProvider.startSymbol('{[{').endSymbol('}]}');
});