### PR TITLE
Properly invoke strict mode

### DIFF
--- a/src/textAngular.js
+++ b/src/textAngular.js
@@ -8,7 +8,7 @@ See README.md or https://github.com/fraywing/textAngular/wiki for requirements a
 */
 
 (function(){ // encapsulate all variables so they don't become global vars
-"Use Strict";					
+"use strict";					
 // IE version detection - http://stackoverflow.com/questions/4169160/javascript-ie-detection-why-not-use-simple-conditional-comments
 // We need this as IE sometimes plays funny tricks with the contenteditable.
 // ----------------------------------------------------------


### PR DESCRIPTION
As of https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode , "use strict" must be written that exact way. "Use Strict" is therefore using wrong syntax, and does not invoke strict mode in Chrome v40.