### PR TITLE
Set dependencies correctly

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "package.json"
   ],
   "dependencies": {
-    "angular": "^1.2.x",
+    "angular": ">=1.2.x",
     "bootstrap-css-only": "^3.0.x",
     "font-awesome": "^4.0.x",
     "rangy": "^1.2.0"

--- a/bower.json
+++ b/bower.json
@@ -24,9 +24,9 @@
   ],
   "dependencies": {
     "angular": ">=1.2.x",
-    "bootstrap-css-only": "^3.0.x",
-    "font-awesome": "^4.0.x",
-    "rangy": "^1.2.0"
+    "bootstrap-css-only": ">=3.0.x",
+    "font-awesome": ">=4.0.x",
+    "rangy": ">=1.2.0"
   },
   "devDependencies": {
     "angular-mocks": "~1.2.x",


### PR DESCRIPTION
Looking at current [requirements](https://github.com/fraywing/textAngular#requirements) and into [semver](https://github.com/npm/node-semver#caret-ranges-123-025-004) is not the same requirements. And while it's working well on flexible bower dependency resolving, it's not working for things like rails-assets.org. 