### PR TITLE
Remove call to rangy.init()

### DIFF
--- a/src/textAngular.js
+++ b/src/textAngular.js
@@ -1823,16 +1823,11 @@ textAngular.config([function(){
 	angular.forEach(taTools, function(value, key){ delete taTools[key];	});
 }]);
 
-textAngular.run([function(){
+textAngular.run(['$window', function($window){
 	/* istanbul ignore next: not sure how to test this */
-	// Require Rangy and rangy savedSelection module.
-	if(!window.rangy){
+	// Require Rangy.
+	if(!$window.rangy){
 		throw("rangy-core.js and rangy-selectionsaverestore.js are required for textAngular to work correctly, rangy-core is not yet loaded.");
-	}else{
-		window.rangy.init();
-		if(!window.rangy.saveSelection){
-			throw("rangy-selectionsaverestore.js is required for textAngular to work correctly.");
-		}
 	}
 }]);
 


### PR DESCRIPTION
On firefox, if I have a page that loads textAngular, but textAngular is
not used at all (or if I load a textAngular element dynamically after
page load), rangy.init() fails. This prevents rangy from ever
initializing, which cripples textAngular.

Here's the stacktrace (shortened slightly):

    "Init listener threw an exception. Continuing." TypeError: sel is null
    Stack trace:
    @http://localhost:5000/assets/rangy/rangy-core.js?body=1:2533:13
    @http://localhost:5000/assets/rangy/rangy-core.js?body=1:2513:10
    window.rangy</api.createModule/<@http://localhost:5000/assets/rangy/rangy-core.js?body=1:236:13
    init@http://localhost:5000/assets/rangy/rangy-core.js?body=1:167:17
    @http://localhost:5000/assets/textAngular/textAngular.js?body=1:1833:3

Interestingly, rangy.init() is only called to test that
rangy.saveSelection is loaded. This is unnecessary - rangy initializes
saveSelection when it loads, and removing the call to rangy.init() does
not affect the check for saveSelection (so far as I can tell).
Furthermore, textAngular 1.2.x never called rangy.init(), but instead relied on
rangy to initialize itself.

To fix the bug I've removed the rangy.init() call. This means we can't
easily check if the SaveSelection module is loaded, but I think it's
fair to assume that if some has read enough of the readme to install
rangy, they'll also have read enough to install SaveSelection.