### PR TITLE
Fixed issue #561: Deffered button action is not performed when editor loses focus

### DIFF
--- a/src/textAngular.js
+++ b/src/textAngular.js
@@ -413,13 +413,14 @@ angular.module('textAngular.factories', [])
 		var deferred = $q.defer(),
 			promise = deferred.promise,
 			_editor = this.$editor();
-		promise['finally'](function(){
-			_editor.endAction.call(_editor);
-		});
 		// pass into the action the deferred function and also the function to reload the current selection if rangy available
 		var result;
 		try{
 			result = this.action(deferred, _editor.startAction());
+			// We set the .finally callback here to make sure it doesn't get executed before any other .then callback.
+			promise['finally'](function(){
+				_editor.endAction.call(_editor);
+			});
 		}catch(exc){
 			$log.error(exc);
 		}


### PR DESCRIPTION
Simply changed where the ```.finally``` callback for a toolbar action promise was being set to make sure it doesn't get executed before any ```.then``` callback that set inside the toolbar action callback.