### PR TITLE
Fix https://github.com/fraywing/textAngular/issues/649

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,6 @@
   ],
   "dependencies": {
     "angular": ">=1.2.x",
-    "bootstrap-css-only": ">=3.0.x",
     "font-awesome": ">=4.0.x",
     "rangy": ">=1.2.0"
   },


### PR DESCRIPTION
This removes the "bootstrap-css-only" dependency from textAngular so that people can choose the Bootstrap package they need, e.g., "bootstrap", "bootstrap-sass-official", "bootstrap-css-only", or whatever. See issues 649.