### PR TITLE
Removed duplicate src attribute on videos

### DIFF
--- a/src/textAngularSetup.js
+++ b/src/textAngularSetup.js
@@ -571,7 +571,7 @@ angular.module('textAngularSetup', [])
 					// create the HTML
 					// for all options see: http://stackoverflow.com/questions/2068344/how-do-i-get-a-youtube-video-thumbnail-from-the-youtube-api
 					// maxresdefault.jpg seems to be undefined on some.
-					var embed = '<img class="ta-insert-video" src="https://img.youtube.com/vi/' + ids[0].substring(3) + '/hqdefault.jpg" ta-insert-video="' + urlLink + '" contenteditable="false" src="" allowfullscreen="true" frameborder="0" />';
+					var embed = '<img class="ta-insert-video" src="https://img.youtube.com/vi/' + ids[0].substring(3) + '/hqdefault.jpg" ta-insert-video="' + urlLink + '" contenteditable="false" allowfullscreen="true" frameborder="0" />';
 					// insert
 					return this.$editor().wrapSelection('insertHTML', embed, true);
 				}


### PR DESCRIPTION
Right now textAngular defines the `src` attribute twice on the `<img>` created when adding a video. This removes the duplicate.