### PR TITLE
handle corner case when commonElement is document.

### DIFF
--- a/src/textAngularSetup.js
+++ b/src/textAngularSetup.js
@@ -277,6 +277,7 @@ angular.module('textAngularSetup', [])
 		},
 		activeState: function(commonElement){
 			var result = false;
+			if (!commonElement || commonElement.nodeName === '#document') return false;
 			if(commonElement) result =
 				commonElement.css('text-align') === 'left' ||
 				commonElement.attr('align') === 'left' ||
@@ -299,6 +300,7 @@ angular.module('textAngularSetup', [])
 		},
 		activeState: function(commonElement){
 			var result = false;
+			if (!commonElement || commonElement.nodeName === '#document') return false;
 			if(commonElement) result = commonElement.css('text-align') === 'right';
 			result = result || this.$editor().queryCommandState('justifyRight');
 			return result;
@@ -312,6 +314,7 @@ angular.module('textAngularSetup', [])
 		},
 		activeState: function(commonElement){
 			var result = false;
+			if (!commonElement || commonElement.nodeName === '#document') return false;
 			if(commonElement) result = commonElement.css('text-align') === 'center';
 			result = result || this.$editor().queryCommandState('justifyCenter');
 			return result;


### PR DESCRIPTION
angular returns an error when the cursor is not inside the editor. This happens when the `commonElement === <'#document'>`. 

this case should be escaped properly.