### PR TITLE
fix(textAngular): fix resize image issue

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -286,6 +286,7 @@ textAngular.directive("textAngular", [
 						event.preventDefault();
 					};
 
+					scope.displayElements.resize.anchors[3].off('mousedown');
 					scope.displayElements.resize.anchors[3].on('mousedown', _resizeMouseDown);
 
 					scope.reflowResizeOverlay(_el);


### PR DESCRIPTION
When resizing an image, the mousedown event does not unbind after each
selection of image so after selecting a few images and then resizing,
all images selected will resize.  Forcing removal of all mousedown
events before the new event is bound resolves this as no other mousedown
event should be bound at this point.