### PR TITLE
fix(textAngular): Use CSS instead of html attributes to resize image. 

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -269,8 +269,8 @@ textAngular.directive("textAngular", [
 								pos.y = ratio > newRatio ? pos.x * ratio : pos.y;
 							}
 							var el = angular.element(_el);
-							el.attr('height', Math.max(0, pos.y));
-							el.attr('width', Math.max(0, pos.x));
+							el.css('height', Math.round(Math.max(0, pos.y)));
+							el.css('width', Math.round(Math.max(0, pos.x)));
 
 							// reflow the popover tooltip
 							scope.reflowResizeOverlay(_el);


### PR DESCRIPTION
Fix image size generated with popover buttons and resize handle.
Because mixing popover size buttons and resize handle can create some funky image sizes because of width and height html attributes is mixed with CSS width and height.