### PR TITLE
Fix(taBind): Reapply selector handles on focus

### DIFF
--- a/src/taBind.js
+++ b/src/taBind.js
@@ -644,6 +644,7 @@ angular.module('textAngular.taBind', ['textAngular.factories', 'textAngular.DOM'
 					element.on('focus', scope.events.focus = function(){
 						_focussed = true;
 						element.removeClass('placeholder-text');
+						_reApplyOnSelectorHandlers();
 					});
 					
 					element.on('mouseup', scope.events.mouseup = function(){


### PR DESCRIPTION
This fixes image overlay not responding until some edit operation has been performed.
Fixes #777 