### PR TITLE
fix(taBind.js): Improved the fix to handle Apple-converted-space, so that we only remove

### DIFF
--- a/src/taBind.js
+++ b/src/taBind.js
@@ -609,8 +609,9 @@ angular.module('textAngular.taBind', ['textAngular.factories', 'textAngular.DOM'
 									// in case of pasting only a span - chrome paste, remove them. THis is just some wierd formatting
 									// if we remove the '<span class="Apple-converted-space"> </span>' here we destroy the spacing
 									// on paste from even ourselves!
-									//text = text.replace(/(<span class=\"Apple-converted-space\">.<\/span>)/ig, '&nbsp;');
-									//text = text.replace(/<(|\/)span[^>]*?>/ig, '');
+									if (!text.match(/<span class=(\"Apple-converted-space\"|\'Apple-converted-space\')>.<\/span>/ig)) {
+										text = text.replace(/<(|\/)span[^>]*?>/ig, '');
+									}
 								}
 								// Webkit on Apple tags
 								text = text.replace(/<br class="Apple-interchange-newline"[^>]*?>/ig, '').replace(/<span class="Apple-converted-space">( |&nbsp;)<\/span>/ig, '&nbsp;');


### PR DESCRIPTION
 the <span...></span> entries when they are now NOT Apple-converted-space
 spans.