### PR TITLE
fix(main.js): we now hide the popover at the end of the image resize.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -242,10 +242,14 @@ textAngular.directive("textAngular", [
 							event.preventDefault();
 							event.stopPropagation();
 							_body.off('mousemove', mousemove);
-							scope.showPopover(_el);
 							// at this point, we need to force the model to update! since the css has changed!
-							// this fixes bug: #862
-							scope.updateTaBindtaTextElement();
+							// this fixes bug: #862 - we now hide the popover -- as this seems more consitent.
+							// there are still issues under firefox, the window does not repaint. -- not sure
+							// how best to resolve this, but clicking anywhere works.
+							scope.$apply(function (){
+								scope.hidePopover();
+								scope.updateTaBindtaTextElement();
+							}, 100);
 						});
 						event.stopPropagation();
 						event.preventDefault();


### PR DESCRIPTION
Hiding the popover at the end of the resize makes more sense.  There are still issues under firefox -- the window does not repaint and so the model does not get updated immediately.  Clicking anywhere fixes this, but I am unclear as to why this happens.  It works fine under Chrome.  Also this is no worse than before!