### PR TITLE
Fix sendKeyCommand when multiple editors are instantiated

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -870,7 +870,7 @@ textAngular.service('textAngularManager', ['taToolExecuteAction', 'taTools', 'ta
 		sendKeyCommand: function(scope, event){
 			Object.keys(editors).forEach(function (key) {
 				/* istanbul ignore else: if nothing to do, do nothing */
-				if (scope._name == key) {
+				if (scope._name === key) {
 					if (editors[key].editorFunctions.sendKeyCommand(event)){
 						/* istanbul ignore else: don't run if already running */
 						if(!scope._bUpdateSelectedStyles){


### PR DESCRIPTION
Ran into this issue when I had multiple editors instantiated and a keypress would activate in the current editor as many times as there were instantiated editors.  

This might be a scoping issue on my part? Regardless, I was definitely confused when I reviewed the previous code for sendEditorKeypress.  It iterated through all editors and activated the appropriate function mapped to the key.  My fix was simply to look for the editor name from which the keypress was sent from.   