### PR TITLE
rm rangy dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,8 +24,7 @@
   ],
   "dependencies": {
     "angular": ">=1.3.x",
-    "font-awesome": ">=4.0.x",
-    "rangy": "~1.3.0"
+    "font-awesome": ">=4.0.x"
   },
   "devDependencies": {
     "angular-mocks": ">=1.3.x",


### PR DESCRIPTION
 Since there are in the textAngular-rangy.min.js, we don't need them.