### PR TITLE
Support for font-style = italic and font-size = [size em/px/%] in sanitize function validStyles

### DIFF
--- a/src/textAngular-sanitize.js
+++ b/src/textAngular-sanitize.js
@@ -535,14 +535,19 @@ function validStyles(styleAttr){
 					|| value === 'justify'
 				)
 			||
-                key === 'text-decoration' && (
-                    value === 'underline'
-                    || value === 'line-through'
-                )
-            || key === 'font-weight' && (
-                    value === 'bold'
-                )
-            ||
+        key === 'text-decoration' && (
+            value === 'underline'
+            || value === 'line-through'
+        )
+      || 
+        key === 'font-weight' && (
+              value === 'bold'
+        )
+      ||
+        key === 'font-style' && (
+          value === 'italic'
+        )
+      ||
 				key === 'float' && (
 					value === 'left'
 					|| value === 'right'

--- a/src/textAngular-sanitize.js
+++ b/src/textAngular-sanitize.js
@@ -541,7 +541,7 @@ function validStyles(styleAttr){
         )
       || 
         key === 'font-weight' && (
-              value === 'bold'
+            value === 'bold'
         )
       ||
         key === 'font-style' && (

--- a/src/textAngular-sanitize.js
+++ b/src/textAngular-sanitize.js
@@ -553,6 +553,10 @@ function validStyles(styleAttr){
 					|| value === 'right'
 					|| value === 'none'
 				)
+      ||
+        key === 'font-size' && (
+					value.match(/[0-9\.]*(px|em|rem|%)/)
+				)
 			||
 				(key === 'width' || key === 'height') && (
 					value.match(/[0-9\.]*(px|em|rem|%)/)

--- a/test/textAngularSanitize/sanitize.spec.js
+++ b/test/textAngularSanitize/sanitize.spec.js
@@ -59,7 +59,13 @@ describe('HTML', function() {
       htmlParser('<!--FOOBAR-->', handler);
       expect(comment).toEqual('FOOBAR');
     });
-
+    
+    it('should parse font-style italic', function(){
+      var html = '<span style="font-type:italic">';
+      htmlParser(html, handler);
+      expect(comment).toEqual(html);
+    });
+    
     it('should throw an exception for invalid comments', function() {
       var caught=false;
       try {


### PR DESCRIPTION
Added support for font-style = italic. Bold and underline were present
except italic was missing.