### PR TITLE
Add ui-codemirror support

### DIFF
--- a/dist/textAngular.js
+++ b/dist/textAngular.js
@@ -1718,25 +1718,39 @@ angular.module('textAngular.taBind', ['textAngular.factories', 'textAngular.DOM'
 							}
 							/* istanbul ignore next: difficult to test as can't seem to select */
 							if(event.keyCode === 13 && !event.shiftKey){
+								var contains = function(a, obj) {
+									for (var i = 0; i < a.length; i++) {
+										if (a[i] === obj) {
+											return true;
+										}
+									}
+									return false;
+								};
 								var $selection;
 								var selection = taSelection.getSelectionElement();
 								if(!selection.tagName.match(VALIDELEMENTS)) return;
 								var _new = angular.element(_defaultVal);
-								if (/^<br(|\/)>$/i.test(selection.innerHTML.trim()) && selection.parentNode.tagName.toLowerCase() === 'blockquote' && !selection.nextSibling) {
-									// if last element in blockquote and element is blank, pull element outside of blockquote.
-									$selection = angular.element(selection);
-									var _parent = $selection.parent();
-									_parent.after(_new);
-									$selection.remove();
-									if(_parent.children().length === 0) _parent.remove();
-									taSelection.setSelectionToElementStart(_new[0]);
-									event.preventDefault();
-								}else if (/^<[^>]+><br(|\/)><\/[^>]+>$/i.test(selection.innerHTML.trim()) && selection.tagName.toLowerCase() === 'blockquote'){
-									$selection = angular.element(selection);
-									$selection.after(_new);
-									$selection.remove();
-									taSelection.setSelectionToElementStart(_new[0]);
-									event.preventDefault();
+								// if we are in the last element of a blockquote, or ul or ol and the element is blank
+								// we need to pull the element outside of the said type
+								var moveOutsideElements = ['blockquote', 'ul', 'ol'];
+								if (contains(moveOutsideElements, selection.parentNode.tagName.toLowerCase())) {
+									if (/^<br(|\/)>$/i.test(selection.innerHTML.trim()) && !selection.nextSibling) {
+										// if last element is blank, pull element outside.
+										$selection = angular.element(selection);
+										var _parent = $selection.parent();
+										_parent.after(_new);
+										$selection.remove();
+										if (_parent.children().length === 0) _parent.remove();
+										taSelection.setSelectionToElementStart(_new[0]);
+										event.preventDefault();
+									}
+									if (/^<[^>]+><br(|\/)><\/[^>]+>$/i.test(selection.innerHTML.trim())) {
+										$selection = angular.element(selection);
+										$selection.after(_new);
+										$selection.remove();
+										taSelection.setSelectionToElementStart(_new[0]);
+										event.preventDefault();
+									}
 								}
 							}
 						}
@@ -2255,6 +2269,9 @@ textAngular.directive("textAngular", [
 							event.stopPropagation();
 							_body.off('mousemove', mousemove);
 							scope.showPopover(_el);
+							// at this point, we need to force the model to update! since the css has changed!
+							// this fixes bug: #862
+							scope.updateTaBindtaTextElement();
 						});
 						event.stopPropagation();
 						event.preventDefault();

--- a/src/demo/codemirror-demo.html
+++ b/src/demo/codemirror-demo.html
@@ -1,0 +1,210 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="UTF-8">
+    <title>textAngular 1.4.6 Demo - Using AngularUI ~ UI Codemirror</title>
+    <meta name="robots" content="noindex">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+    <link rel='stylesheet' href='../bower_components/font-awesome/css/font-awesome.css'>
+    <link rel='stylesheet' href='../dist/textAngular.css'>
+
+
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.7.0/codemirror.css" />
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.7.0/addon/fold/foldgutter.css" />
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.7.0/addon/display/fullscreen.css" />
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.7.0/theme/material.min.css" />
+    <style>
+    .ta-editor {
+        min-height: 300px;
+        height: auto;
+        overflow: auto;
+        font-family: inherit;
+        font-size: 100%;
+    }
+    </style>
+
+    <!-- Angular.js -->
+      <script src='https://ajax.googleapis.com/ajax/libs/angularjs/1.3.11/angular.min.js'></script>
+
+    <!-- Codemirror -->
+      <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.7.0/codemirror.js"></script>
+
+    <!-- Codemirror Addons -->
+      <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.7.0/addon/edit/closetag.js"></script>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.7.0/addon/edit/matchtags.js"></script>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.7.0/addon/edit/closebrackets.js"></script>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.7.0/addon/edit/matchbrackets.js"></script>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.7.0/addon/fold/foldcode.js"></script>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.7.0/addon/fold/foldgutter.js"></script>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.7.0/addon/fold/brace-fold.js"></script>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.7.0/addon/fold/xml-fold.js"></script>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.7.0/addon/fold/markdown-fold.js"></script>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.7.0/addon/fold/comment-fold.js"></script>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.7.0/addon/display/fullscreen.js"></script>
+      <!-- Codemirror formatting.js addon -->
+      <script>
+        (function() {
+          CodeMirror.extendMode("css", {
+            commentStart: "/*",
+            commentEnd: "*/",
+            newlineAfterToken: function(type, content) {
+              return /^[;{}]$/.test(content);
+            }
+          });
+          CodeMirror.extendMode("javascript", {
+            commentStart: "/*",
+            commentEnd: "*/",
+            // FIXME semicolons inside of for
+            newlineAfterToken: function(type, content, textAfter, state) {
+              if (this.jsonMode) {
+                return /^[\[,{]$/.test(content) || /^}/.test(textAfter);
+              } else {
+                if (content == ";" && state.lexical && state.lexical.type == ")") return false;
+                return /^[;{}]$/.test(content) && !/^;/.test(textAfter);
+              }
+            }
+          });
+          CodeMirror.extendMode("xml", {
+            commentStart: "<!--",
+            commentEnd: "-->",
+            newlineAfterToken: function(type, content, textAfter) {
+              return type == "tag" && />$/.test(content) || /^</.test(textAfter);
+            }
+          });
+          // Comment/uncomment the specified range
+          CodeMirror.defineExtension("commentRange", function (isComment, from, to) {
+            var cm = this, curMode = CodeMirror.innerMode(cm.getMode(), cm.getTokenAt(from).state).mode;
+            cm.operation(function() {
+              if (isComment) { // Comment range
+                cm.replaceRange(curMode.commentEnd, to);
+                cm.replaceRange(curMode.commentStart, from);
+                if (from.line == to.line && from.ch == to.ch) // An empty comment inserted - put cursor inside
+                  cm.setCursor(from.line, from.ch + curMode.commentStart.length);
+              } else { // Uncomment range
+                var selText = cm.getRange(from, to);
+                var startIndex = selText.indexOf(curMode.commentStart);
+                var endIndex = selText.lastIndexOf(curMode.commentEnd);
+                if (startIndex > -1 && endIndex > -1 && endIndex > startIndex) {
+                  // Take string till comment start
+                  selText = selText.substr(0, startIndex)
+                  // From comment start till comment end
+                    + selText.substring(startIndex + curMode.commentStart.length, endIndex)
+                  // From comment end till string end
+                    + selText.substr(endIndex + curMode.commentEnd.length);
+                }
+                cm.replaceRange(selText, from, to);
+              }
+            });
+          });
+          // Applies automatic mode-aware indentation to the specified range
+          CodeMirror.defineExtension("autoIndentRange", function (from, to) {
+            var cmInstance = this;
+            this.operation(function () {
+              for (var i = from.line; i <= to.line; i++) {
+                cmInstance.indentLine(i, "smart");
+              }
+            });
+          });
+          // Applies automatic formatting to the specified range
+          CodeMirror.defineExtension("autoFormatRange", function (from, to) {
+            var cm = this;
+            var outer = cm.getMode(), text = cm.getRange(from, to).split("\n");
+            var state = CodeMirror.copyState(outer, cm.getTokenAt(from).state);
+            var tabSize = cm.getOption("tabSize");
+            var out = "", lines = 0, atSol = from.ch == 0;
+            function newline() {
+              out += "\n";
+              atSol = true;
+              ++lines;
+            }
+            for (var i = 0; i < text.length; ++i) {
+              var stream = new CodeMirror.StringStream(text[i], tabSize);
+              while (!stream.eol()) {
+                var inner = CodeMirror.innerMode(outer, state);
+                var style = outer.token(stream, state), cur = stream.current();
+                stream.start = stream.pos;
+                if (!atSol || /\S/.test(cur)) {
+                  out += cur;
+                  atSol = false;
+                }
+                if (!atSol && inner.mode.newlineAfterToken &&
+                    inner.mode.newlineAfterToken(style, cur, stream.string.slice(stream.pos) || text[i+1] || "", inner.state))
+                  newline();
+              }
+              if (!stream.pos && outer.blankLine) outer.blankLine(state);
+              if (!atSol) newline();
+            }
+            cm.operation(function () {
+              cm.replaceRange(out, from, to);
+              for (var cur = from.line + 1, end = from.line + lines; cur <= end; ++cur)
+                cm.indentLine(cur, "smart");
+              cm.setSelection(from, cm.getCursor(false));
+            });
+          });
+        })();
+      </script>
+
+    <!-- Codemirror Modes -->
+      <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.7.0/mode/xml/xml.js"></script>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.7.0/mode/css/css.js"></script>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.7.0/mode/javascript/javascript.js"></script>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.7.0/mode/htmlmixed/htmlmixed.js"></script>
+
+    <!-- Angular-ui ~ Codemirror -->
+      <script src="//rawgit.com/angular-ui/ui-codemirror/master/src/ui-codemirror.js"></script>
+
+    <!-- textAngular -->
+      <script src='../dist/textAngular-rangy.min.js'></script>
+      <script src='../dist/textAngular-sanitize.min.js'></script>
+      <script src='../dist/textAngular.min.js'></script>
+
+</head>
+
+<body>
+    <div ng-app="textAngularTest" ng-controller="wysiwygeditor" class="container app">
+        <h1>Editor</h1>
+        <h2 style="font-size: 2rem; color: grey;">Use the CodeMirror editor on HTML mode.</h2>
+        <div class="well">
+          <text-angular name="htmlcontent" ng-model="htmlcontent" codemirror codemirror-opts="codemirrorOpts"></text-angular>
+        </div>
+    </div>
+
+    <script type="text/javascript">
+    angular.module("textAngularTest", ['textAngular', 'ui.codemirror'])
+        .controller('wysiwygeditor', function wysiwygeditor($scope) {
+            $scope.orightml = '<h2>Try me!</h2><p>textAngular is a super cool WYSIWYG Text Editor directive for AngularJS</p><p><img class="ta-insert-video" ta-insert-video="http://www.youtube.com/embed/2maA1-mvicY" src="" allowfullscreen="true" width="300" frameborder="0" height="250"/></p><p><b>Features:</b></p><ol><li>Automatic Seamless Two-Way-Binding</li><li>Super Easy <b>Theming</b> Options</li><li style="color: green;">Simple Editor Instance Creation</li><li>Safely Parses Html for Custom Toolbar Icons</li><li class="text-danger">Doesn&apos;t Use an iFrame</li><li>Works with Firefox, Chrome, and IE9+</li></ol><p><b>Code at GitHub:</b> <a href="https://github.com/fraywing/textAngular">Here</a> </p><h4>Supports non-latin Characters</h4><p>昮朐 魡 燚璒瘭 譾躒鑅, 皾籈譧 紵脭脧 逯郹酟 煃 瑐瑍, 踆跾踄 趡趛踠 顣飁 廞 熥獘 豥 蔰蝯蝺 廦廥彋 蕍蕧螛 溹溦 幨懅憴 妎岓岕 緁, 滍 蘹蠮 蟷蠉蟼 鱐鱍鱕, 阰刲 鞮鞢騉 烳牼翐 魡 骱 銇韎餀 媓幁惁 嵉愊惵 蛶觢, 犝獫 嶵嶯幯 縓罃蔾 魵 踄 罃蔾 獿譿躐 峷敊浭, 媓幁 黐曮禷 椵楘溍 輗 漀 摲摓 墐墆墏 捃挸栚 蛣袹跜, 岓岕 溿 斶檎檦 匢奾灱 逜郰傃</p>';
+            $scope.htmlcontent = $scope.orightml;
+            // CodeMirror options is not required to ui-codemirror works
+            $scope.codemirrorOpts =  {
+                mode: 'htmlmixed',
+                fixedGutters: true,
+                lineNumbers: true,
+                lineWrapping : true,
+                theme: 'material',
+                indentUnit: 4,
+                indentWithTabs: true,
+                autoCloseTags: true,
+                matchTags: {bothTags: true},
+                autoCloseBrackets: true,
+                matchBrackets: true,
+                foldGutter: true,
+                gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'],
+                extraKeys: {
+                    'F11': function(cm) {
+                        cm.setOption('fullScreen', !cm.getOption('fullScreen'));
+                    },
+                    'Esc': function(cm) {
+                        if (cm.getOption('fullScreen')){
+                            cm.setOption('fullScreen', false);
+                        }
+                    },
+                    'Ctrl-J': "toMatchingTag"
+                }
+            };
+            $scope.disabled = false;
+        });
+    </script>
+</body>
+
+</html>

--- a/src/textAngular.css
+++ b/src/textAngular.css
@@ -39,6 +39,10 @@
 	padding: 6px 12px;
 }
 
+.ta-editor.ta-codemirror{
+  padding: 0;
+}
+
 .ta-editor:focus {
 	user-select: text;
 }


### PR DESCRIPTION
I needed to use a CodeMirror editor instead of textarea for a better edit the code, but i had problems to make this using the current possibilities. So, i did a propose to add a native support for ui-codemirror to textAngular project and i created the codemirror-demo.html demo file, to do a simple example of codemirror usage with textAngular.