### PR TITLE
Show switch HTML button all the time [But editor needs to be clicked]

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -969,6 +969,9 @@ textAngular.directive('textAngularToolbar', [
 						return scope._parent;
 					},
 					isDisabled: function(){
+						if (this.name === 'html' && scope._parent.startAction) {
+							return false;
+						}
 						// to set your own disabled logic set a function or boolean on the tool called 'disabled'
 						return ( // this bracket is important as without it it just returns the first bracket and ignores the rest
 							// when the button's disabled function/value evaluates to true


### PR DESCRIPTION
# Show switch HTML button is enabled all the time. 
The only gotcha is that editor has to be once clicked to enable the same. After that, it will be enabled even after losing focus.
All the test cases run fine.
