### PR TITLE
Fix(readme): typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ For Additional options see the [github Wiki](https://github.com/fraywing/textAng
 textAngular uses ```execCommand``` for the rich-text functionality.
 That being said, its still a fairly experimental browser feature-set, and may not behave the same in all browsers - see http://tifftiff.de/contenteditable/compliance_test.html for a full compliance list.
 It has been tested to work on Chrome, Safari, Opera, Firefox and Internet Explorer 8+.
-If you find something, please let me know - throw me a message, or submit a issue request!
+If you find something, please let me know - throw me a message, or submit an issue request!
 
 ### FAQ
 
@@ -153,7 +153,7 @@ New buttons can be created using taRegisterTool. Examples can be found inside de
 This project is licensed under the [MIT license](http://opensource.org/licenses/MIT).
 
 
-## Contributers
+## Contributors
 
 Special thanks to all the contributions thus far!
 


### PR DESCRIPTION
Replace `a` with `an`
`Contributers` → `Contributors`