### PR TITLE
Ignore INDEX_SIZE_ERR error that occurs when selection is empty

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -545,7 +545,10 @@ textAngular.directive("textAngular", [
 					/* istanbul ignore next: This check is to ensure multiple timeouts don't exist */
 					if(_updateSelectedStylesTimeout) $timeout.cancel(_updateSelectedStylesTimeout);
 					// test if the common element ISN'T the root ta-text node
-					if((_selection = taSelection.getSelectionElement()) !== undefined && _selection.parentNode !== scope.displayElements.text[0]){
+					try {
+						_selection = taSelection.getSelectionElement();
+					} catch(e) {}
+					if(_selection !== undefined && _selection.parentNode !== scope.displayElements.text[0]){
 						_toolbars.updateSelectedStyles(angular.element(_selection));
 					}else _toolbars.updateSelectedStyles();
 					// used to update the active state when a key is held down, ie the left arrow


### PR DESCRIPTION
INDEX_SIZE_ERR sometimes occurs when I type any characters in text-angular element, and open a bootstrap modal window immediately.