### PR TITLE
Fix(DOM, globals, textAngular.spec): Corrected bugs around Firefox we…

### DIFF
--- a/src/globals.js
+++ b/src/globals.js
@@ -53,8 +53,10 @@ function stripHtmlToText(html)
 {
 	var tmp = document.createElement("DIV");
 	tmp.innerHTML = html;
-	var res = tmp.textContent || tmp.innerText || "";
-	return res.trim();
+	var res = tmp.textContent || tmp.innerText || '';
+	res.replace('\u200B', ''); // zero width space
+	res = res.trim();
+	return res;
 }
 // get html
 function getDomFromHtml(html)

--- a/src/taBind.js
+++ b/src/taBind.js
@@ -868,19 +868,6 @@ angular.module('textAngular.taBind', ['textAngular.factories', 'textAngular.DOM'
 					element.on('focus', scope.events.focus = function(){
 						_focussed = true;
 						element.removeClass('placeholder-text');
-						/* istanbul ignore next: this is only triggered under Firefox and rare! */
-						try {
-							var _cont = taSelection.getSelectionElement();
-							// in Firefox, there is an issue that the selection is initially set to the
-							// whole container! And when that happens the first character is inserted before
-							// the <p><br></p> which is bad
-							// So we detect the whole container selected and then reset the selection to the
-							// <p>
-							if (_cont.tagName.toLowerCase() === 'div' && _cont.id === scope.displayElements.text.attr('id')) {
-								// opps we are actually selecting the whole container!
-								taSelection.setSelectionToElementStart(_cont.firstChild);
-							}
-						}catch(e){}
 						_reApplyOnSelectorHandlers();
 					});
 

--- a/test/textAngular.spec.js
+++ b/test/textAngular.spec.js
@@ -65,6 +65,8 @@ describe('textAngular', function(){
 				//console.log('Took', (t1 - t0).toFixed(4), 'milliseconds to do something!');
 				expect(duration < 0.001);
 				expect(stripped).toBe('Lorem ipsumLorem ipsum');
+				stripped = stripHtmlToText(' \n &#8203;&#8203; &#8203; ');
+				expect(stripped).toBe('');
 			});
 		});
 	});


### PR DESCRIPTION
…irdness

 - DOM: major fix to handle Firefox weirdness around <br> insertions
        We now insert zero width spaces in place of <br> that is
        a '&#8203' character.
        This corrects taExecCommand() to function properly on Firefox.
 - globals: stripHtmlToText() now handles zero width spaces
 - textAngular.spec: added test for ero width spaces