### PR TITLE
Fix(main, textAngularManager.spec): Corrected issues with the toolbar…

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -20,7 +20,7 @@ textAngular.directive("textAngular", [
 			link: function(scope, element, attrs, ngModel){
 				// all these vars should not be accessable outside this directive
 				var _keydown, _keyup, _keypress, _mouseup, _focusin, _focusout,
-					_originalContents, _toolbars,
+					_originalContents, _editorFunctions,
 					_serial = (attrs.serial) ? attrs.serial : Math.floor(Math.random() * 10000000000000000),
 					_taExecCommand, _resizeMouseDown, _updateSelectedStylesTimeout;
 
@@ -330,7 +330,6 @@ textAngular.directive("textAngular", [
 					// if rangy library is loaded return a function to reload the current selection
 					_savedSelection = rangy.saveSelection();
 					return function(){
-						//console.log('restore to:', _savedSelection);
 						if(_savedSelection) rangy.restoreSelection(_savedSelection);
 					};
 				};
@@ -356,7 +355,7 @@ textAngular.directive("textAngular", [
 				_focusin = function(){
 					scope.focussed = true;
 					element.addClass(scope.classes.focussed);
-					_toolbars.focus();
+					_editorFunctions.focus();
 					element.triggerHandler('focus');
 				};
 				scope.displayElements.html.on('focus', _focusin);
@@ -375,7 +374,7 @@ textAngular.directive("textAngular", [
 					// if we are NOT runnig an action and have NOT focussed again on the text etc then fire the blur events
 					if(!scope._actionRunning && $document[0].activeElement !== scope.displayElements.html[0] && $document[0].activeElement !== scope.displayElements.text[0]){
 						element.removeClass(scope.classes.focussed);
-						_toolbars.unfocus();
+						_editorFunctions.unfocus();
 						// to prevent multiple apply error defer to next seems to work.
 						$timeout(function(){
 							scope._bUpdateSelectedStyles = false;
@@ -481,7 +480,9 @@ textAngular.directive("textAngular", [
 					}
 				});
 
-				if(attrs.taTargetToolbars) _toolbars = textAngularManager.registerEditor(scope._name, scope, attrs.taTargetToolbars.split(','));
+				if(attrs.taTargetToolbars) {
+					_editorFunctions = textAngularManager.registerEditor(scope._name, scope, attrs.taTargetToolbars.split(','));
+				}
 				else{
 					var _toolbar = angular.element('<div text-angular-toolbar name="textAngularToolbar' + _serial + '">');
 					// passthrough init of toolbar options
@@ -494,7 +495,7 @@ textAngular.directive("textAngular", [
 
 					element.prepend(_toolbar);
 					$compile(_toolbar)(scope.$parent);
-					_toolbars = textAngularManager.registerEditor(scope._name, scope, ['textAngularToolbar' + _serial]);
+					_editorFunctions = textAngularManager.registerEditor(scope._name, scope, ['textAngularToolbar' + _serial]);
 				}
 
 				scope.$on('$destroy', function(){
@@ -504,7 +505,7 @@ textAngular.directive("textAngular", [
 
 				// catch element select event and pass to toolbar tools
 				scope.$on('ta-element-select', function(event, element){
-					if(_toolbars.triggerElementSelect(event, element)){
+					if(_editorFunctions.triggerElementSelect(event, element)){
 						scope['reApplyOnSelectorHandlerstaTextElement' + _serial]();
 					}
 				});
@@ -550,8 +551,8 @@ textAngular.directive("textAngular", [
 					if(_updateSelectedStylesTimeout) $timeout.cancel(_updateSelectedStylesTimeout);
 					// test if the common element ISN'T the root ta-text node
 					if((_selection = taSelection.getSelectionElement()) !== undefined && _selection.parentNode !== scope.displayElements.text[0]){
-						_toolbars.updateSelectedStyles(angular.element(_selection));
-					}else _toolbars.updateSelectedStyles();
+						_editorFunctions.updateSelectedStyles(angular.element(_selection));
+					}else _editorFunctions.updateSelectedStyles();
 					// used to update the active state when a key is held down, ie the left arrow
 					/* istanbul ignore else: browser only check */
 					if(scope._bUpdateSelectedStyles) _updateSelectedStylesTimeout = $timeout(scope.updateSelectedStyles, 200);
@@ -603,7 +604,7 @@ textAngular.directive("textAngular", [
 					/* istanbul ignore else: this is for catching the jqLite testing*/
 					if(eventData) angular.extend(event, eventData);
 					scope.$apply(function(){
-						if(_toolbars.sendKeyCommand(event)){
+						if(_editorFunctions.sendKeyCommand(event)){
 							/* istanbul ignore else: don't run if already running */
 							if(!scope._bUpdateSelectedStyles){
 								scope.updateSelectedStyles();
@@ -629,13 +630,12 @@ textAngular.directive("textAngular", [
 		};
 	}
 ]);
-textAngular.service('textAngularManager', ['taToolExecuteAction', 'taTools', 'taRegisterTool', '$interval', '$rootScope', function(taToolExecuteAction, taTools, taRegisterTool, $interval, $rootScope){
+textAngular.service('textAngularManager', ['taToolExecuteAction', 'taTools', 'taRegisterTool', '$interval', '$rootScope', '$log',
+	function(taToolExecuteAction, taTools, taRegisterTool, $interval, $rootScope, $log){
 	// this service is used to manage all textAngular editors and toolbars.
 	// All publicly published functions that modify/need to access the toolbar or editor scopes should be in here
 	// these contain references to all the editors and toolbars that have been initialised in this app
 	var toolbars = {}, editors = {};
-	// toolbarScopes is an ARRAY of toolbar scopes
-	var toolbarScopes = [];
 	// we touch the time any change occurs through register of an editor or tool so that we
 	// in the future will fire and event to trigger an updateSelection
 	var timeRecentModification = 0;
@@ -671,55 +671,62 @@ textAngular.service('textAngularManager', ['taToolExecuteAction', 'taTools', 'ta
 	// We also need to set the tools to be updated to be the toolbars...
 	return {
 		// register an editor and the toolbars that it is affected by
-		registerEditor: function(name, scope, targetToolbars){
+		registerEditor: function(editorName, editorScope, targetToolbars){
+			// NOTE: name === editorScope._name
+			// targetToolbars is an [] of 'toolbar name's
 			// targetToolbars are optional, we don't require a toolbar to function
-			if(!name || name === '') throw('textAngular Error: An editor requires a name');
-			if(!scope) throw('textAngular Error: An editor requires a scope');
-			if(editors[name]) throw('textAngular Error: An Editor with name "' + name + '" already exists');
-			angular.forEach(targetToolbars, function(_name){
-				if(toolbars[_name]) toolbarScopes.push(toolbars[_name]);
-				// if it doesn't exist it may not have been compiled yet and it will be added later
-			});
-			editors[name] = {
-				scope: scope,
+			if(!editorName || editorName === '') throw('textAngular Error: An editor requires a name');
+			if(!editorScope) throw('textAngular Error: An editor requires a scope');
+			if(editors[editorName]) throw('textAngular Error: An Editor with name "' + editorName + '" already exists');
+			editors[editorName] = {
+				scope: editorScope,
 				toolbars: targetToolbars,
+				// toolbarScopes used by this editor
+				toolbarScopes: [],
 				_registerToolbarScope: function(toolbarScope){
 					// add to the list late
-					if(this.toolbars.indexOf(toolbarScope.name) >= 0) toolbarScopes.push(toolbarScope);
+					if(this.toolbars.indexOf(toolbarScope.name) >= 0) {
+						// if this toolbarScope is being used by this editor we add it as one of the scopes
+						this.toolbarScopes.push(toolbarScope);
+					}
 				},
 				// this is a suite of functions the editor should use to update all it's linked toolbars
 				editorFunctions: {
 					disable: function(){
 						// disable all linked toolbars
-						angular.forEach(toolbarScopes, function(toolbarScope){ toolbarScope.disabled = true; });
+						angular.forEach(editors[editorName].toolbarScopes, function(toolbarScope){
+							toolbarScope.disabled = true;
+						});
 					},
 					enable: function(){
 						// enable all linked toolbars
-						angular.forEach(toolbarScopes, function(toolbarScope){ toolbarScope.disabled = false; });
+						angular.forEach(editors[editorName].toolbarScopes, function(toolbarScope){
+							toolbarScope.disabled = false;
+						});
 					},
 					focus: function(){
 						// this should be called when the editor is focussed
-						angular.forEach(toolbarScopes, function(toolbarScope){
-							toolbarScope._parent = scope;
+						angular.forEach(editors[editorName].toolbarScopes, function(toolbarScope){
+							toolbarScope._parent = editorScope;
 							toolbarScope.disabled = false;
 							toolbarScope.focussed = true;
-							scope.focussed = true;
 						});
+						editorScope.focussed = true;
 					},
 					unfocus: function(){
 						// this should be called when the editor becomes unfocussed
-						angular.forEach(toolbarScopes, function(toolbarScope){
+						angular.forEach(editors[editorName].toolbarScopes, function(toolbarScope){
 							toolbarScope.disabled = true;
 							toolbarScope.focussed = false;
 						});
-						scope.focussed = false;
+						editorScope.focussed = false;
 					},
 					updateSelectedStyles: function(selectedElement){
 						// update the active state of all buttons on liked toolbars
-						angular.forEach(toolbarScopes, function(toolbarScope){
+						angular.forEach(editors[editorName].toolbarScopes, function(toolbarScope){
 							angular.forEach(toolbarScope.tools, function(toolScope){
 								if(toolScope.activeState){
-									toolbarScope._parent = scope;
+									toolbarScope._parent = editorScope;
 									// selectedElement may be undefined if nothing selected
 									toolScope.active = toolScope.activeState(selectedElement);
 								}
@@ -731,9 +738,9 @@ textAngular.service('textAngularManager', ['taToolExecuteAction', 'taTools', 'ta
 						var result = false;
 						if(event.ctrlKey || event.metaKey || event.specialKey) angular.forEach(taTools, function(tool, name){
 							if(tool.commandKeyCode && (tool.commandKeyCode === event.which || tool.commandKeyCode === event.specialKey)){
-								for(var _t = 0; _t < toolbarScopes.length; _t++){
-									if(toolbarScopes[_t].tools[name] !== undefined){
-										taToolExecuteAction.call(toolbarScopes[_t].tools[name], scope);
+								for(var _t = 0; _t < editors[editorName].toolbarScopes.length; _t++){
+									if(editors[editorName].toolbarScopes[_t].tools[name] !== undefined){
+										taToolExecuteAction.call(editors[editorName].toolbarScopes[_t].tools[name], editorScope);
 										result = true;
 										break;
 									}
@@ -789,9 +796,9 @@ textAngular.service('textAngularManager', ['taToolExecuteAction', 'taTools', 'ta
 							for(var _i = 0; _i < workerTools.length; _i++){
 								var tool = workerTools[_i].tool;
 								var name = workerTools[_i].name;
-								for(var _t = 0; _t < toolbarScopes.length; _t++){
-									if(toolbarScopes[_t].tools[name] !== undefined){
-										tool.onElementSelect.action.call(toolbarScopes[_t].tools[name], event, element, scope);
+								for(var _t = 0; _t < editors[editorName].toolbarScopes.length; _t++){
+									if(editors[editorName].toolbarScopes[_t].tools[name] !== undefined){
+										tool.onElementSelect.action.call(editors[editorName].toolbarScopes[_t].tools[name], event, element, editorScope);
 										result = true;
 										break;
 									}
@@ -803,8 +810,14 @@ textAngular.service('textAngularManager', ['taToolExecuteAction', 'taTools', 'ta
 					}
 				}
 			};
+			angular.forEach(targetToolbars, function(_name){
+				if(toolbars[_name]) {
+					editors[editorName].toolbarScopes.push(toolbars[_name]);
+				}
+				// if it doesn't exist it may not have been compiled yet and it will be added later
+			});
 			touchModification();
-			return editors[name].editorFunctions;
+			return editors[editorName].editorFunctions;
 		},
 		// retrieve editor by name, largely used by testing suites only
 		retrieveEditor: function(name){
@@ -815,13 +828,16 @@ textAngular.service('textAngularManager', ['taToolExecuteAction', 'taTools', 'ta
 			touchModification();
 		},
 		// registers a toolbar such that it can be linked to editors
-		registerToolbar: function(scope){
-			if(!scope) throw('textAngular Error: A toolbar requires a scope');
-			if(!scope.name || scope.name === '') throw('textAngular Error: A toolbar requires a name');
-			if(toolbars[scope.name]) throw('textAngular Error: A toolbar with name "' + scope.name + '" already exists');
-			toolbars[scope.name] = scope;
+		registerToolbar: function(toolbarScope){
+			if(!toolbarScope) throw('textAngular Error: A toolbar requires a scope');
+			if(!toolbarScope.name || toolbarScope.name === '') throw('textAngular Error: A toolbar requires a name');
+			if(toolbars[toolbarScope.name]) throw('textAngular Error: A toolbar with name "' + toolbarScope.name + '" already exists');
+			toolbars[toolbarScope.name] = toolbarScope;
+			// walk all the editors and connect this toolbarScope to the editors.... if we need to.  This way, it does
+			// not matter if we register the editors after the toolbars or not
+			// Note the editor will ignore this toolbarScope if it is not connected to it...
 			angular.forEach(editors, function(_editor){
-				_editor._registerToolbarScope(scope);
+				_editor._registerToolbarScope(toolbarScope);
 			});
 			touchModification();
 		},
@@ -839,14 +855,6 @@ textAngular.service('textAngularManager', ['taToolExecuteAction', 'taTools', 'ta
 		},
 		unregisterToolbar: function(name){
 			delete toolbars[name];
-			// we remove the scope from the toolbarScopes so that we no longer have a memory leak.
-			var tmp = [];
-			for (var index in toolbarScopes) {
-				if (toolbarScopes[index].name !== name) {
-					tmp.push(toolbarScopes[index]);
-				}
-			}
-			toolbarScopes = tmp;
 			touchModification();
 		},
 		// functions for updating the toolbar buttons display
@@ -963,7 +971,13 @@ textAngular.service('textAngularManager', ['taToolExecuteAction', 'taTools', 'ta
 		// return the current version of textAngular in use to the user
 		getVersion: function () { return textAngularVersion; },
 		// for testing
-		getToolbarScopes: function () { return toolbarScopes; },
+		getToolbarScopes: function () {
+			var tmp=[];
+			angular.forEach(editors, function (_editor) {
+				tmp = tmp.concat(_editor.toolbarScopes);
+			});
+			return tmp;
+		},
 		// save the selection ('range') for the given editor
 		saveFocusSelection: function (name, range) {
 			editors[name].savedFocusRange = range;

--- a/test/textAngularManager.spec.js
+++ b/test/textAngularManager.spec.js
@@ -58,12 +58,13 @@ describe('textAngularManager', function(){
 				textAngularManager.registerToolbar({name: 'test'});
 				textAngularManager.registerToolbar({name: 'test1'});
 				expect(textAngularManager.getToolbarScopes().length).toBe(2);
-				textAngularManager.unregisterEditor('testeditor');
-				// note: unregisterEditor does nothing to the toolbarScopes
+				// note: unregisterToolbar does nothing to the toolbarScopes
 				textAngularManager.unregisterToolbar('test');
-				// this will have removed one of the toolbarScopes
-				expect(textAngularManager.getToolbarScopes().length).toBe(1);
+				expect(textAngularManager.getToolbarScopes().length).toBe(2);
 				textAngularManager.unregisterToolbar('test1');
+				expect(textAngularManager.getToolbarScopes().length).toBe(2);
+				textAngularManager.unregisterEditor('testeditor');
+				// this will have deleted the toolbarScopes held in the editor
 				expect(textAngularManager.getToolbarScopes().length).toBe(0);
 			}));
 		});
@@ -226,8 +227,14 @@ describe('textAngularManager', function(){
 		describe('interacting', function(){
 			var $rootScope, textAngularManager, editorFuncs, testbar1, testbar2, testbar3;
 			var editorScope = {};
-			beforeEach(inject(function(_textAngularManager_){
+			var $log;
+			beforeEach(inject(function(_textAngularManager_, _$log_){
 				textAngularManager = _textAngularManager_;
+				$log = _$log_;
+			}));
+			afterEach(inject(function(){
+				// turn on to display log messages when needed
+				//console.log($log.debug.logs);
 			}));
 
 			describe('active state', function(){


### PR DESCRIPTION
… being active on all editors

  Also some cleanup: _toolbars -> _editorFunctions
  Now toolbarScopes are tied to each editor which is cleaner and makes more sense.
  AND the toolbarScopes are deleted when the editor is deleted which is better and
  no longer tied to the toolbar.
  We also added some code to enable $log messages in the karma testing when necessary
  See the textAngularManager.spec.js file for details looking at 'var $log', beforeEach() and afterEach()