### PR TITLE
fix(DOM, globals, main, taBind): Fix for #1205 Duplicating content in…

### DIFF
--- a/src/demo/demo.html
+++ b/src/demo/demo.html
@@ -40,7 +40,7 @@
         <button type="button" ng-click="htmlcontent = orightml">Reset</button>
         <p>Note: although we support classes and styles, angularjs' ng-bind-html directive will strip out all style attributes.</p>
         <h1>Option to masquerade as a fancy text-area - complete with form submission and optional ngModel</h1>
-        <text-angular name="htmlcontent" ng-model="htmlcontenttwo">
+        <text-angular name="htmlcontenttwo" ng-model="htmlcontenttwo">
             <p>Any <b>HTML</b> we put in-between the text-angular tags gets automatically put into the editor if there <strong style="font-size: 12pt;"><u><em>is not</em></u></strong> a value assigned to the ngModel.</p>
             <p>If there is a value assigned to the ngModel, it replaces any html here. To see this, uncomment the line at the bottom of demo.html</p>
         </text-angular>

--- a/src/globals.js
+++ b/src/globals.js
@@ -77,7 +77,13 @@ function getDomFromHtml(html)
 
 var BLOCKELEMENTS = /^(address|article|aside|audio|blockquote|canvas|center|dd|div|dl|fieldset|figcaption|figure|footer|form|h1|h2|h3|h4|h5|h6|header|hgroup|hr|noscript|ol|output|p|pre|section|table|tfoot|ul|video)$/i;
 var LISTELEMENTS = /^(ul|li|ol)$/i;
-var VALIDELEMENTS = /^(address|article|aside|audio|blockquote|canvas|center|dd|div|dl|fieldset|figcaption|figure|footer|form|h1|h2|h3|h4|h5|h6|header|hgroup|hr|noscript|ol|output|p|pre|section|table|tfoot|ul|video|li)$/i;
+// updated VALIDELEMENTS to include #text and span so that we can use nodeName instead of tagName
+var VALIDELEMENTS = /^(#text|span|address|article|aside|audio|blockquote|canvas|center|dd|div|dl|fieldset|figcaption|figure|footer|form|h1|h2|h3|h4|h5|h6|header|hgroup|hr|noscript|ol|output|p|pre|section|table|tfoot|ul|video|li)$/i;
+
+var ENTER_KEYCODE = 13;
+var TAB_KEYCODE = 9;
+var LEFT_ARROW = 37;
+var RIGHT_ARROW = 39;
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim#Compatibility
 /* istanbul ignore next: trim shim for older browsers */

--- a/src/main.js
+++ b/src/main.js
@@ -531,7 +531,9 @@ textAngular.directive("textAngular", [
 				// changes from taBind back up to here
 				scope.$watch('html', function(newValue, oldValue){
 					if(newValue !== oldValue){
-						if(attrs.ngModel && ngModel.$viewValue !== newValue) ngModel.$setViewValue(newValue);
+						if(attrs.ngModel && ngModel.$viewValue !== newValue) {
+							ngModel.$setViewValue(newValue);
+						}
 						scope.displayElements.forminput.val(newValue);
 					}
 				});


### PR DESCRIPTION
…side <p>

 DOM - added taSelection.updateLeftArrowKey() and taSelection.updateRightArrowKey()
       so that we check the selection after the cursor is moved and correct for the
       differences between Firefox and Chrome.
     - added taSelection.getFlattenedDom() that returns the nodes needed to allow
       the updateLeftArrowKey() and updateRightArrowKey() to function.
       Basically this returns a flattened set of Nodes that have text content as well
       as the associated parent Nodes.
     - insertHtml() now allows the insertion of a text with the zero-width space character.
 demo.html - fixed a bug where is had two editors with the same name.
 globals - added '#text' and 'spam' to the VALIDELEMENTS
         - defined ENTER_KEYCODE, TAB_KEYCODE, LEFT_ARROW, RIGHT_ARROW to make the code
           more transparent.
 main - small formatting change to the code.
 taBind - now use ENTER_KEYCODE, TAB_KEYCODE, LEFT_ARROW, RIGHT_ARROW definitions from global
        - shifted to using nodeName whenever we call match(VALIDELEMENTS)
        - element.on('keyup') now detects the LEFT_ARROW and RIGHT_ARROW and calls the
          taSelection.updateLeftArrowKey() or taSelection.updateRightArrowKey()