### PR TITLE
fix(DOM, main, taBind, demo.html, textAngular.com.html)

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -423,7 +423,14 @@ function($document, taDOM, $log){
 	};
 	var api = {
 		getSelection: function(){
-			var range = rangy.getSelection().getRangeAt(0);
+			var range;
+			try {
+				// catch any errors from rangy and ignore the issue
+				range = rangy.getSelection().getRangeAt(0);
+			} catch(e) {
+				//console.info(e);
+				return undefined;
+			}
 			var container = range.commonAncestorContainer;
             var selection = {
 				start: brException(range.startContainer, range.startOffset),
@@ -690,7 +697,12 @@ function($document, taDOM, $log){
 		},
 		// Some basic selection functions
 		getSelectionElement: function () {
-			return api.getSelection().container;
+			var s = api.getSelection();
+			if (s) {
+				return api.getSelection().container;
+			} else {
+				return undefined;
+			}
 		},
 		setSelection: function(el, start, end){
 			var range = rangy.createRange();

--- a/src/demo/demo.html
+++ b/src/demo/demo.html
@@ -7,6 +7,7 @@
     <meta name="robots" content="noindex">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
     <link rel='stylesheet' href='../bower_components/font-awesome/css/font-awesome.css'>
+    <link rel="stylesheet" href="http://textangular.com/dist/textAngular.css" type="text/css">
     <style>
     .ta-editor {
         min-height: 300px;
@@ -21,9 +22,16 @@
     </style>
 
     <script src='https://ajax.googleapis.com/ajax/libs/angularjs/1.3.11/angular.min.js'></script>
+    <!-- enable this section or the non-minimized section below -->
     <% js.forEach(function(each){ %>
       <script src='../<%= each %>'></script>
     <% }); %>
+    <!-- non minimized version for ease of debugging
+        <script src='../dist/textAngular-rangy.min.js'></script>
+        <script src='../dist/textAngular-sanitize.js'></script>
+        <script src='../dist/textAngular.js'></script>
+        <script src='../dist/textAngularSetup.js'></script>
+    -->
 </head>
 
 <body>

--- a/src/demo/textAngular.com.html
+++ b/src/demo/textAngular.com.html
@@ -11,18 +11,25 @@
     <meta name="copyright" content="Austin Anderson. All rights reserved">
     <meta charset="utf-8">
     <title>textAngular :: Lightweight Angular.js, Javascript Wysiwyg/Text-Editor</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="shortcut icon" href="images/favicon.png">
-    <link rel="author" href="http://www.twitter.com/codeandwaffles">
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css">
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.min.css">
+    <link rel="author" href="https://www.linkedin.com/in/austinanderson1">
+    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.1.0/css/bootstrap.min.css">
+    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Roboto:400,300">
-    <link rel="stylesheet" href="http://textangular.com/css/style.css" type="text/css">
+    <link rel="stylesheet" href="http://textangular.com/dist/textAngular.css" type="text/css">
     <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.11/angular.min.js" type="text/javascript"></script>
+    <script src='https://ajax.googleapis.com/ajax/libs/angularjs/1.3.11/angular.min.js'></script>
+    <!-- enable this section or the non-minimized section below -->
     <% js.forEach(function(each){ %>
-        <script src='../<%= each %>'></script>
+    <script src='../<%= each %>'></script>
     <% }); %>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/prettify/r298/prettify.js" type="text/javascript"></script>
-    <script src="http://resources.infolinks.com/js/infolinks_main.js" type="text/javascript"></script>
+    <!-- non minimized version for ease of debugging
+        <script src='../dist/textAngular-rangy.min.js'></script>
+        <script src='../dist/textAngular-sanitize.js'></script>
+        <script src='../dist/textAngular.js'></script>
+        <script src='../dist/textAngularSetup.js'></script>
+    -->
 </head>
 
 <body>

--- a/src/main.js
+++ b/src/main.js
@@ -145,7 +145,7 @@ textAngular.directive("textAngular", [
 					scope.displayElements.popoverArrow.css('margin-left', (Math.min(_targetLeft, (Math.max(0, _targetLeft - _maxLeft))) - 11) + 'px');
 				};
 				scope.hidePopover = function(){
-					scope.displayElements.popover.css('display', '');
+					scope.displayElements.popover.css('display', 'none');
 					scope.displayElements.popoverContainer.attr('style', '');
 					scope.displayElements.popoverContainer.attr('class', 'popover-content');
 					scope.displayElements.popover.removeClass('in');
@@ -240,7 +240,7 @@ textAngular.directive("textAngular", [
 				/* istanbul ignore next: pretty sure phantomjs won't test this */
 				scope.hideResizeOverlay = function(){
 					scope.displayElements.resize.anchors[3].off('mousedown', _resizeMouseDown);
-					scope.displayElements.resize.overlay.css('display', '');
+					scope.displayElements.resize.overlay.css('display', 'none');
 				};
 
 				// allow for insertion of custom directives on the textarea and div

--- a/src/taBind.js
+++ b/src/taBind.js
@@ -962,7 +962,7 @@ angular.module('textAngular.taBind', ['textAngular.factories', 'textAngular.DOM'
 
 					element.on('mouseup', scope.events.mouseup = function(){
 						var _selection = taSelection.getSelection();
-						if(_selection.start.element === element[0] && element.children().length) taSelection.setSelectionToElementStart(element.children()[0]);
+						if(_selection && _selection.start.element === element[0] && element.children().length) taSelection.setSelectionToElementStart(element.children()[0]);
 					});
 
 					// prevent propagation on mousedown in editor, see #206


### PR DESCRIPTION
 - DOM, taBind: improved the getSelection() so that it no longer throws rangy errors.
   If range.getSlection() erros it return undefined now.
   Also getSelectionElement() returns undefined on error as well.
   This eliminates a rare rangy invalid index error.
 - demo.html is improved and it is easier to select non-minimized textAngular
   sources.
 - textAngular.com.html is improved and it is easier to select non-minimized
   textAngular sources.
 - main: now we use the proper 'none' for the display property instead of ''