### PR TITLE
fix: Fix console errors caused by #text nodes.

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -168,7 +168,7 @@ angular.module('textAngular.DOM', ['textAngular.factories'])
 			//console.log('************** selectedElement:', selectedElement);
 			var $selected = angular.element(selectedElement);
 			//if(selectedElement !== undefined && selectedElement.tagName !== undefined){
-			var tagName = selectedElement.tagName.toLowerCase();
+			var tagName = (selectedElement.tagName && selectedElement.tagName.toLowerCase()) || "";
 			if(command.toLowerCase() === 'insertorderedlist' || command.toLowerCase() === 'insertunorderedlist'){
 				var selfTag = taBrowserTag((command.toLowerCase() === 'insertorderedlist')? 'ol' : 'ul');
 				if(tagName === selfTag){
@@ -374,7 +374,7 @@ angular.module('textAngular.DOM', ['textAngular.factories'])
 				return;
 			}else if(command.toLowerCase() === 'createlink'){
 				/* istanbul ignore next: firefox specific fix */
-				if (taSelection.getSelectionElement().tagName.toLowerCase() === 'a') {
+				if (tagName === 'a') {
 					// already a link!!! we are just replacing it...
 					taSelection.getSelectionElement().href = options;
 					return;

--- a/src/taBind.js
+++ b/src/taBind.js
@@ -155,12 +155,12 @@ angular.module('textAngular.taBind', ['textAngular.factories', 'textAngular.DOM'
 				_defaultTest = (_browserDetect.ie === undefined)? '<div><br></div>' : (_browserDetect.ie >= 11)? '<p><br></p>' : (_browserDetect.ie <= 8)? '<P>&nbsp;</P>' : '<p>&nbsp;</p>';
 			}else{
 				_defaultVal = (_browserDetect.ie === undefined || _browserDetect.ie >= 11)?
-					'<' + attrs.taDefaultWrap + '><br></' + attrs.taDefaultWrap + '>' :
+					(attrs.taDefaultWrap.toLowerCase() === 'br' ? '<BR><BR>' : '<' + attrs.taDefaultWrap + '><br></' + attrs.taDefaultWrap + '>') :
 					(_browserDetect.ie <= 8)?
 						'<' + attrs.taDefaultWrap.toUpperCase() + '></' + attrs.taDefaultWrap.toUpperCase() + '>' :
 						'<' + attrs.taDefaultWrap + '></' + attrs.taDefaultWrap + '>';
 				_defaultTest = (_browserDetect.ie === undefined || _browserDetect.ie >= 11)?
-					'<' + attrs.taDefaultWrap + '><br></' + attrs.taDefaultWrap + '>' :
+					(attrs.taDefaultWrap.toLowerCase() === 'br' ? '<br><br>' : '<' + attrs.taDefaultWrap + '><br></' + attrs.taDefaultWrap + '>') :
 					(_browserDetect.ie <= 8)?
 						'<' + attrs.taDefaultWrap.toUpperCase() + '>&nbsp;</' + attrs.taDefaultWrap.toUpperCase() + '>' :
 						'<' + attrs.taDefaultWrap + '>&nbsp;</' + attrs.taDefaultWrap + '>';

--- a/src/taBind.js
+++ b/src/taBind.js
@@ -861,7 +861,7 @@ angular.module('textAngular.taBind', ['textAngular.factories', 'textAngular.DOM'
 								// we ignore any ENTER_	KEYCODE that is anything but plain or a shift one...
 							} else {
 								// if enter - insert new taDefaultWrap, if shift+enter insert <br/>
-								if(_defaultVal !== '' && event.keyCode === _ENTER_KEYCODE && !event.ctrlKey && !event.metaKey && !event.altKey){
+								if(_defaultVal !== '' && _defaultVal !== '<BR><BR>' && event.keyCode === _ENTER_KEYCODE && !event.ctrlKey && !event.metaKey && !event.altKey){
 									if(!event.shiftKey){
 										// new paragraph, br should be caught correctly
 										var selection = taSelection.getSelectionElement();

--- a/src/textAngularSetup.js
+++ b/src/textAngularSetup.js
@@ -829,7 +829,7 @@ angular.module('textAngularSetup', [])
 				/* istanbul ignore next: don't know how to test this... since it needs a dialogPrompt */
 				// block javascript here
 				if (!blockJavascript(imageLink)) {
-					if (taSelection.getSelectionElement().tagName.toLowerCase() === 'a') {
+					if (taSelection.getSelectionElement().tagName && taSelection.getSelectionElement().tagName.toLowerCase() === 'a') {
 						// due to differences in implementation between FireFox and Chrome, we must move the
 						// insertion point past the <a> element, otherwise FireFox inserts inside the <a>
 						// With this change, both FireFox and Chrome behave the same way!
@@ -876,7 +876,7 @@ angular.module('textAngularSetup', [])
 						// maxresdefault.jpg seems to be undefined on some.
 						var embed = '<img class="ta-insert-video" src="https://img.youtube.com/vi/' + videoId + '/hqdefault.jpg" ta-insert-video="' + urlLink + '" contenteditable="false" allowfullscreen="true" frameborder="0" />';
 						/* istanbul ignore next: don't know how to test this... since it needs a dialogPrompt */
-						if (taSelection.getSelectionElement().tagName.toLowerCase() === 'a') {
+						if (taSelection.getSelectionElement().tagName && taSelection.getSelectionElement().tagName.toLowerCase() === 'a') {
 							// due to differences in implementation between FireFox and Chrome, we must move the
 							// insertion point past the <a> element, otherwise FireFox inserts inside the <a>
 							// With this change, both FireFox and Chrome behave the same way!
@@ -901,7 +901,7 @@ angular.module('textAngularSetup', [])
 			var urlLink;
 			// if this link has already been set, we need to just edit the existing link
 			/* istanbul ignore if: we do not test this */
-			if (taSelection.getSelectionElement().tagName.toLowerCase() === 'a') {
+			if (taSelection.getSelectionElement().tagName && taSelection.getSelectionElement().tagName.toLowerCase() === 'a') {
 				urlLink = $window.prompt(taTranslations.insertLink.dialogPrompt, taSelection.getSelectionElement().href);
 			} else {
 				urlLink = $window.prompt(taTranslations.insertLink.dialogPrompt, 'http://');


### PR DESCRIPTION
Using ta-default-wrap="br" causes various errors when selected element is a #text node.