### PR TITLE
fix(taBind, textAngular-sanitize): Corrected and enhanced formating c…

### DIFF
--- a/src/taBind.js
+++ b/src/taBind.js
@@ -689,7 +689,11 @@ angular.module('textAngular.taBind', ['textAngular.factories', 'textAngular.DOM'
 
 							if(_pasteHandler) text = _pasteHandler(scope, {$html: text}) || text;
 
+							// turn span vertical-align:super into <sup></sup>
+							text = text.replace(/<span style=("|')([^<]*?)vertical-align\s*:\s*super;?([^>]*?)("|')>([^<]+?)<\/span>/g, "<sup style='$2$3'>$5</sup>");
+
 							text = taSanitize(text, '', _disableSanitizer);
+							//console.log('DONE\n', text);
 
 							taSelection.insertHtml(text, element[0]);
 							$timeout(function(){

--- a/src/textAngular-sanitize.js
+++ b/src/textAngular-sanitize.js
@@ -548,15 +548,37 @@ function validStyles(styleAttr){
           value === 'italic'
         )
       ||
-				key === 'float' && (
-					value === 'left'
-					|| value === 'right'
-					|| value === 'none'
-				)
+        key === 'float' && (
+            value === 'left'
+            || value === 'right'
+            || value === 'none'
+        )
+      ||
+        key === 'vertical-align' && (
+            value === 'baseline'
+            || value === 'sub'
+            || value === 'super'
+            || value === 'test-top'
+            || value === 'text-bottom'
+            || value === 'middle'
+            || value === 'top'
+            || value === 'bottom'
+            || value.match(/[0-9]*(px|em)/)
+            || value.match(/[0-9]+?%/)
+        )
       ||
         key === 'font-size' && (
-					value.match(/[0-9\.]*(px|em|rem|%)/)
-				)
+            value === 'xx-small'
+            || value === 'x-small'
+            || value === 'small'
+            || value === 'medium'
+            || value === 'large'
+            || value === 'x-large'
+            || value === 'xx-large'
+            || value === 'larger'
+            || value === 'smaller'
+            || value.match(/[0-9]*\.?[0-9]*(px|em|rem|mm|q|cm|in|pt|pc|%)/)
+                               )
 			||
 				(key === 'width' || key === 'height') && (
 					value.match(/[0-9\.]*(px|em|rem|%)/)


### PR DESCRIPTION
…omming from Word and OneNote

 - taBind: replaced <span style='...veritcal-align:super;...'>...</span> -> <sup style='...'>...</sup>
   so that we now see superscripts from OneNote
 - textAngular-sanitize: vertical-align is now accepted as a style adjustment
   and font-size is now enhanced to accept more of the standard settings.