### PR TITLE
fixed issue #1201 with <img> tag when it inserts outside of <p>

### DIFF
--- a/src/globals.js
+++ b/src/globals.js
@@ -75,7 +75,7 @@ function getDomFromHtml(html)
 
 // Global to textAngular REGEXP vars for block and list elements.
 
-var BLOCKELEMENTS = /^(address|article|aside|audio|blockquote|canvas|center|dd|div|dl|fieldset|figcaption|figure|footer|form|h1|h2|h3|h4|h5|h6|header|hgroup|hr|noscript|ol|output|p|pre|section|table|tfoot|ul|video)$/i;
+var BLOCKELEMENTS = /^(address|article|aside|audio|blockquote|canvas|center|dd|div|dl|fieldset|figcaption|figure|footer|form|h1|h2|h3|h4|h5|h6|header|hgroup|hr|noscript|ol|output|p|pre|section|table|tfoot|ul|video|img)$/i;
 var LISTELEMENTS = /^(ul|li|ol)$/i;
 // updated VALIDELEMENTS to include #text and span so that we can use nodeName instead of tagName
 var VALIDELEMENTS = /^(#text|span|address|article|aside|audio|blockquote|canvas|center|dd|div|dl|fieldset|figcaption|figure|footer|form|h1|h2|h3|h4|h5|h6|header|hgroup|hr|noscript|ol|output|p|pre|section|table|tfoot|ul|video|li)$/i;


### PR DESCRIPTION
Hi, Please see the issue #1201. I noticed the similar behaviour with Chrome AND Firefox. 

Unfortunately I do not really understand what is `BLOCKELEMENTS` variable... Probably it is something that has child elements... but I noticed `video` element there which is probably do not contain child elements (sorry for my very poor knowledge of frontend technologies).

So I just added `<img>` tag to this variable and it works. 

Please update me if it is wrong/dirty fix. 