### PR TITLE
fix(DOM): corrected a bug where we could not insertHTML when the docu…

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -249,7 +249,6 @@ angular.module('textAngular.DOM', ['textAngular.factories'])
                         //console.log('inner whole container', selectedElement.childNodes);
                         _innerNode = '<div>' + __h + '</div>';
                         selectedElement.innerHTML = _innerNode;
-                        //console.log('childNodes:', selectedElement.childNodes);
                         taSelection.setSelectionToElementEnd(selectedElement.childNodes[0]);
                         selectedElement = taSelection.getSelectionElement();
                     } else if (selectedElement.tagName.toLowerCase() === 'span' &&
@@ -298,9 +297,7 @@ angular.module('textAngular.DOM', ['textAngular.factories'])
                             // Firefox adds <br>'s and so we remove the <br>
                             __h = __h.replace(/<br>/i, '&#8203;');  // no space-space
 							selectedElement.innerHTML = __h;
-							taSelection.setSelectionToElementEnd(selectedElement.childNodes[0]);
-							selectedElement = taSelection.getSelectionElement();
-                        }
+						}
                     } else if (selectedElement.tagName.toLowerCase() === 'li' &&
                         ourSelection && ourSelection.start &&
                         ourSelection.start.offset === ourSelection.end.offset) {
@@ -310,8 +307,6 @@ angular.module('textAngular.DOM', ['textAngular.factories'])
                             // Firefox adds <br>'s and so we remove the <br>
                             __h = __h.replace(/<br>/i, '');  // nothing
 							selectedElement.innerHTML = __h;
-							taSelection.setSelectionToElementEnd(selectedElement.childNodes[0]);
-							selectedElement = taSelection.getSelectionElement();
                         }
                     }
                 }
@@ -559,6 +554,7 @@ angular.module('textAngular.DOM', ['textAngular.factories'])
 					tagEnd = '</a>',
 					_selection = taSelection.getSelection();
 				if(_selection.collapsed){
+					//console.log('collapsed');
 					// insert text at selection, then select then just let normal exec-command run
 					taSelection.insertHtml(tagBegin + options + tagEnd, topNode);
 				}else if(rangy.getSelection().getRangeAt(0).canSurroundContents()){
@@ -567,6 +563,7 @@ angular.module('textAngular.DOM', ['textAngular.factories'])
 				}
 				return;
 			}else if(command.toLowerCase() === 'inserthtml'){
+				//console.log('inserthtml');
 				taSelection.insertHtml(options, topNode);
 				return;
 			}

--- a/src/taBind.js
+++ b/src/taBind.js
@@ -965,7 +965,11 @@ angular.module('textAngular.taBind', ['textAngular.factories', 'textAngular.DOM'
 									//console.log('new:', _val);
 									_setViewValue(_val, true);
 								}
-								rangy.restoreSelection(_savedSelection);
+								// if the savedSelection marker is gone at this point, we cannot restore the selection!!!
+                                //console.log('rangy.restoreSelection', ngModel.$viewValue.length, _savedSelection);
+								if (ngModel.$viewValue.length !== 0) {
+                                    rangy.restoreSelection(_savedSelection);
+                                }
 							}, 1000);
 						}
 					});

--- a/src/textAngularSetup.js
+++ b/src/textAngularSetup.js
@@ -547,15 +547,24 @@ angular.module('textAngularSetup', [])
 			/* istanbul ignore next: */
 			if (commonElement && commonElement.nodeName === '#document') return false;
 			var result = false;
-			if (commonElement)
-				result =
-					commonElement.css('text-align') === 'left' ||
-					commonElement.attr('align') === 'left' ||
-					(
-						commonElement.css('text-align') !== 'right' &&
-						commonElement.css('text-align') !== 'center' &&
-						commonElement.css('text-align') !== 'justify' && !this.$editor().queryCommandState('justifyRight') && !this.$editor().queryCommandState('justifyCenter')
-					) && !this.$editor().queryCommandState('justifyFull');
+			if (commonElement) {
+                // commonELement.css('text-align') can throw an error 'Cannot read property 'defaultView' of null' in rare conditions
+				// so we do try catch here...
+				try {
+                    result =
+                        commonElement.css('text-align') === 'left' ||
+                        commonElement.attr('align') === 'left' ||
+                        (
+                            commonElement.css('text-align') !== 'right' &&
+                            commonElement.css('text-align') !== 'center' &&
+                            commonElement.css('text-align') !== 'justify' && !this.$editor().queryCommandState('justifyRight') && !this.$editor().queryCommandState('justifyCenter')
+                        ) && !this.$editor().queryCommandState('justifyFull');
+                } catch(e) {
+					/* istanbul ignore next: error handler */
+                    //console.log(e);
+					result = false;
+				}
+            }
 			result = result || this.$editor().queryCommandState('justifyLeft');
 			return result;
 		}
@@ -570,7 +579,17 @@ angular.module('textAngularSetup', [])
 			/* istanbul ignore next: */
 			if (commonElement && commonElement.nodeName === '#document') return false;
 			var result = false;
-			if(commonElement) result = commonElement.css('text-align') === 'right';
+			if(commonElement) {
+                // commonELement.css('text-align') can throw an error 'Cannot read property 'defaultView' of null' in rare conditions
+                // so we do try catch here...
+                try {
+                    result = commonElement.css('text-align') === 'right';
+                } catch(e) {
+					/* istanbul ignore next: error handler */
+                    //console.log(e);
+                    result = false;
+                }
+            }
 			result = result || this.$editor().queryCommandState('justifyRight');
 			return result;
 		}
@@ -583,7 +602,17 @@ angular.module('textAngularSetup', [])
 		},
 		activeState: function(commonElement){
 			var result = false;
-			if(commonElement) result = commonElement.css('text-align') === 'justify';
+			if(commonElement) {
+                // commonELement.css('text-align') can throw an error 'Cannot read property 'defaultView' of null' in rare conditions
+                // so we do try catch here...
+                try {
+					result = commonElement.css('text-align') === 'justify';
+                } catch(e) {
+					/* istanbul ignore next: error handler */
+                    //console.log(e);
+                    result = false;
+                }
+            }
 			result = result || this.$editor().queryCommandState('justifyFull');
 			return result;
 		}
@@ -598,7 +627,18 @@ angular.module('textAngularSetup', [])
 			/* istanbul ignore next: */
 			if (commonElement && commonElement.nodeName === '#document') return false;
 			var result = false;
-			if(commonElement) result = commonElement.css('text-align') === 'center';
+			if(commonElement) {
+                // commonELement.css('text-align') can throw an error 'Cannot read property 'defaultView' of null' in rare conditions
+                // so we do try catch here...
+				try {
+                    result = commonElement.css('text-align') === 'center';
+                } catch(e) {
+					/* istanbul ignore next: error handler */
+					//console.log(e);
+					result = false;
+            	}
+
+        	}
 			result = result || this.$editor().queryCommandState('justifyCenter');
 			return result;
 		}


### PR DESCRIPTION
…ment was empty.

fix(taBind): corrected a bug where we attempted to restore the selection in element.on('input') when the
 document was empty after a delete.
fix(textAngularSetup): corrected a bug where we would throw an error in taRegisterTool('justifyFull'),
 taRegisterTool('justifyRight'), and taRegisterTool('justifyLeft') when it was illegal to call
 .css('text-align).  We now catch and suppress those errors.