### PR TITLE
fix(taBind): Add code to handle pasting text in IE

### DIFF
--- a/src/taBind.js
+++ b/src/taBind.js
@@ -721,6 +721,14 @@ angular.module('textAngular.taBind', ['textAngular.factories', 'textAngular.DOM'
 						element.addClass('processing-paste');
 						var pastedContent;
 						var clipboardData = (e.originalEvent || e).clipboardData;
+						/* istanbul ignore next: Handle legacy IE paste */
+						if ( !clipboardData && window.clipboardData && window.clipboardData.getData ){
+							pastedContent = window.clipboardData.getData("Text");
+							processpaste(pastedContent);
+							e.stopPropagation();
+							e.preventDefault();
+							return false;
+						}
 						if (clipboardData && clipboardData.getData && clipboardData.types.length > 0) {// Webkit - get data from clipboard, put into editdiv, cleanup, then cancel event
 							var _types = "";
 							for(var _t = 0; _t < clipboardData.types.length; _t++){


### PR DESCRIPTION
It seems no attempt was made to hande text-paste operations in IE browsers. I added code to get the pasted text, which fixes a number of problems pasting text in IE browsers.
