### PR TITLE
Fix removing blockquote when ta-default-wrap=br

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -444,10 +444,17 @@ angular.module('textAngular.DOM', ['textAngular.factories'])
                         $target.remove();
                         $target = next;
                     }else{
-                        defaultWrapper.append($target[0].childNodes);
-                        $target.after(defaultWrapper);
-                        $target.remove();
-                        $target = defaultWrapper;
+                        if (taDefaultWrap === 'br'){
+                            var firstChild = angular.element($target[0].childNodes[0]);
+                            $target.replaceWith($target[0].childNodes);
+                            $target = firstChild;
+                           return;
+                        } else {
+                            defaultWrapper.append($target[0].childNodes);
+                            $target.after(defaultWrapper);
+                            $target.remove();
+                            $target = defaultWrapper;
+                        }
                     }
                 }else if($target.parent()[0].tagName.toLowerCase() === optionsTagName &&
                     !$target.parent().hasClass('ta-bind')){

--- a/src/factories.js
+++ b/src/factories.js
@@ -1,9 +1,10 @@
 angular.module('textAngular.factories', [])
-.factory('taBrowserTag', [function(){
+.factory('taBrowserTag', ['taOptions', function( taOptions ){
     return function(tag){
+        tag = tag || taOptions.taDefaultWrap;
         /* istanbul ignore next: ie specific test */
         if(!tag) return (_browserDetect.ie <= 8)? 'P' : 'p';
-        else if(tag === '') return (_browserDetect.ie === undefined)? 'div' : (_browserDetect.ie <= 8)? 'P' : 'p';
+        /* istanbul ignore next: ie specific test */
         else return (_browserDetect.ie <= 8)? tag.toUpperCase() : tag;
     };
 }]).factory('taApplyCustomRenderers', ['taCustomRenderers', 'taDOM', function(taCustomRenderers, taDOM){

--- a/src/taBind.js
+++ b/src/taBind.js
@@ -166,6 +166,9 @@ angular.module('textAngular.taBind', ['textAngular.factories', 'textAngular.DOM'
                         '<' + attrs.taDefaultWrap.toUpperCase() + '>&nbsp;</' + attrs.taDefaultWrap.toUpperCase() + '>' :
                         '<' + attrs.taDefaultWrap + '>&nbsp;</' + attrs.taDefaultWrap + '>';
             }
+            taOptions.taDefaultWrap = attrs.taDefaultWrap;
+            taOptions._defaultVal = _defaultVal;
+            taOptions._defaultTest = _defaultTest;
 
             /* istanbul ignore else */
             if(!ngModelOptions.$options) ngModelOptions.$options = {}; // ng-model-options support

--- a/test/textAngular.spec.js
+++ b/test/textAngular.spec.js
@@ -613,27 +613,61 @@ describe('textAngular', function(){
         });
     });
 
-    describe('should respect the ta-default-wrap value', function(){
-        it('with ng-model', inject(function($rootScope, $compile, textAngularManager){
-            $rootScope.html = '';
-            $compile('<text-angular ta-default-wrap="div" name="test" ng-model="html"></text-angular>')($rootScope);
-            element = textAngularManager.retrieveEditor('test').scope.displayElements.text;
-            $rootScope.$digest();
-            element.triggerHandler('focus');
-            $rootScope.$digest();
-            expect(element.html()).toBe('<div><br></div>');
-        }));
-        it('without ng-model', inject(function($rootScope, $compile, textAngularManager){
-            $compile('<text-angular ta-default-wrap="div" name="test"></text-angular>')($rootScope);
-            element = textAngularManager.retrieveEditor('test').scope.displayElements.text;
-            $rootScope.$digest();
-            element.triggerHandler('focus');
-            $rootScope.$digest();
-            expect(element.html()).toBe('<div><br></div>');
-        }));
-    });
+	describe('should respect the ta-default-wrap value', function(){
+		it('with ng-model', inject(function($rootScope, $compile, textAngularManager){
+			$rootScope.html = '';
+			$compile('<text-angular ta-default-wrap="div" name="test" ng-model="html"></text-angular>')($rootScope);
+			element = textAngularManager.retrieveEditor('test').scope.displayElements.text;
+			$rootScope.$digest();
+			element.triggerHandler('focus');
+			$rootScope.$digest();
+			expect(element.html()).toBe('<div><br></div>');
+		}));
+		it('without ng-model', inject(function($rootScope, $compile, textAngularManager){
+			$compile('<text-angular ta-default-wrap="div" name="test"></text-angular>')($rootScope);
+			element = textAngularManager.retrieveEditor('test').scope.displayElements.text;
+			$rootScope.$digest();
+			element.triggerHandler('focus');
+			$rootScope.$digest();
+			expect(element.html()).toBe('<div><br></div>');
+		}));
+		it('without ng-model ta-default-wrap="br"', inject(function($rootScope, $compile, textAngularManager){
+			$compile('<text-angular ta-default-wrap="br" name="test"></text-angular>')($rootScope);
+			element = textAngularManager.retrieveEditor('test').scope.displayElements.text;
+			$rootScope.$digest();
+			element.triggerHandler('focus');
+			$rootScope.$digest();
+			expect(element.html()).toBe('<br><br>');
+		}));
+	});
 
-
+	describe('should respect the ta-default-wrap value and undo blockquote correctly', function(){
+		beforeEach(function(){
+			module(function($provide){
+				$provide.value('taSelection', {
+					element: undefined,
+					getSelectionElement: function (){ return this.element; },
+					getOnlySelectedElements: function(){ return [].slice.call(this.element.childNodes); },
+					setSelectionToElementStart: function (){ return; },
+					setSelectionToElementEnd: function (){ return; }
+				});
+			});
+		});
+		it('without ng-model ta-default-wrap="br" deselect blockquotes', inject(function($document, $rootScope, $compile, textAngularManager, taSelection, taExecCommand){
+			$rootScope.html = '<br><blockquote><b>Test</b></blockquote>';
+			element = $compile('<div ta-bind ta-default-wrap="br" contenteditable="contenteditable" ng-model="html"></div>')($rootScope);
+			$document.find('body').append(element);
+			$rootScope.$digest();
+			element.triggerHandler('focus');
+			$rootScope.$digest();
+			var sel_elem = element.find('b')[0];
+			taSelection.element = sel_elem;
+			$rootScope.$digest();
+			taExecCommand()('formatBlock', false, '<BLOCKQUOTE>');
+			$rootScope.$digest();
+			expect(element.html()).toBe('<br><br><br><b>Test</b>');
+		}));
+	});
 
     describe('should respect taUnsafeSanitizer attribute', function () {
         var element2, displayElements, $timeout;


### PR DESCRIPTION
This replaces https://github.com/fraywing/textAngular/pull/1385 due to merge errors. 

When blockquote is removed when ta-default-wrap=br, it results in removal of the text. The text is not actually removed, it is inside an opening and closing BR tag which makes the text seem to be removed in some browsers. The opening and closing BR tags are a problem in quite a few places withing textAngular, due to treating BR like a P or DIV element which has opening and closing tags.

This also includes updated tests, for testing blockquote removal when ta-default-wrap=br

