### PR TITLE
fix(taBind): pasting partial paragraphs from word

### DIFF
--- a/src/taBind.js
+++ b/src/taBind.js
@@ -572,7 +572,8 @@ angular.module('textAngular.taBind', ['textAngular.factories', 'textAngular.DOM'
                                             tagName !== 'h4' &&
                                             tagName !== 'h5' &&
                                             tagName !== 'h6' &&
-                                            tagName !== 'table'){
+                                            tagName !== 'table' &&
+                                            tagName !== 'span'){
                                             continue;
                                         }
                                     }


### PR DESCRIPTION
fix for pasting partial paragraphs from word. Previously when a part of a paragraph was pasted from word, nothing happened. This was because a partial paragraph is suurounded by a span tag in the clipboard, and a span tag was removed from the paste output. With this fix the span tag is allowed in pasting from a word document, thus allowing pasting a partial paragraph from word.