### PR TITLE
Improve default createLink action edition

### DIFF
--- a/dist/textAngular.js
+++ b/dist/textAngular.js
@@ -1047,13 +1047,27 @@ angular.module('textAngular.DOM', ['textAngular.factories'])
                 $target[0].focus();
                 return;
             }else if(command.toLowerCase() === 'createlink'){
+                var url,text;
+                if(Array.isArray(options)) {
+                    url = options[0];
+                    text = options[1];
+                    if (options[2]){
+                        text = '<i class="' + options[2] + '"></i> <span>' + text + '</span>';
+                    }
+                } else {
+                    url = options;
+                    text = options;
+                }
+
                 /* istanbul ignore next: firefox specific fix */
                 if (tagName === 'a') {
                     // already a link!!! we are just replacing it...
-                    taSelection.getSelectionElement().href = options;
+                    taSelection.getSelectionElement().href = url;
+                    taSelection.getSelectionElement().html = text;
+
                     return;
                 }
-                var tagBegin = '<a href="' + options + '" target="' +
+                var tagBegin = '<a href="' + url + '" target="' +
                         (defaultTagAttributes.a.target ? defaultTagAttributes.a.target : '') +
                         '">',
                     tagEnd = '</a>',
@@ -1061,7 +1075,7 @@ angular.module('textAngular.DOM', ['textAngular.factories'])
                 if(_selection.collapsed){
                     //console.log('collapsed');
                     // insert text at selection, then select then just let normal exec-command run
-                    taSelection.insertHtml(tagBegin + options + tagEnd, topNode);
+                    taSelection.insertHtml(tagBegin + text + tagEnd, topNode);
                 }else if(rangy.getSelection().getRangeAt(0).canSurroundContents()){
                     var node = angular.element(tagBegin + tagEnd)[0];
                     rangy.getSelection().getRangeAt(0).surroundContents(node);

--- a/dist/textAngular.umd.js
+++ b/dist/textAngular.umd.js
@@ -4,13 +4,13 @@
     define('textAngular', ["rangy","rangy/lib/rangy-selectionsaverestore"], function (a0,b1) {
       return (root['textAngular.name'] = factory(a0,b1));
     });
-  } else if (typeof exports === 'object') {
+  } else if (typeof module === 'object' && module.exports) {
     // Node. Does not work with strict CommonJS, but
     // only CommonJS-like environments that support module.exports,
     // like Node.
     module.exports = factory(require("rangy"),require("rangy/lib/rangy-selectionsaverestore"));
   } else {
-    root['textAngular'] = factory(rangy);
+    root['textAngular'] = factory(root["rangy"]);
   }
 }(this, function (rangy) {
 
@@ -2077,13 +2077,27 @@ angular.module('textAngular.DOM', ['textAngular.factories'])
                 $target[0].focus();
                 return;
             }else if(command.toLowerCase() === 'createlink'){
+                var url,text;
+                if(Array.isArray(options)) {
+                    url = options[0];
+                    text = options[1];
+                    if (options[2]){
+                        text = '<i class="' + options[2] + '"></i> <span>' + text + '</span>';
+                    }
+                } else {
+                    url = options;
+                    text = options;
+                }
+
                 /* istanbul ignore next: firefox specific fix */
                 if (tagName === 'a') {
                     // already a link!!! we are just replacing it...
-                    taSelection.getSelectionElement().href = options;
+                    taSelection.getSelectionElement().href = url;
+                    taSelection.getSelectionElement().html = text;
+
                     return;
                 }
-                var tagBegin = '<a href="' + options + '" target="' +
+                var tagBegin = '<a href="' + url + '" target="' +
                         (defaultTagAttributes.a.target ? defaultTagAttributes.a.target : '') +
                         '">',
                     tagEnd = '</a>',
@@ -2091,7 +2105,7 @@ angular.module('textAngular.DOM', ['textAngular.factories'])
                 if(_selection.collapsed){
                     //console.log('collapsed');
                     // insert text at selection, then select then just let normal exec-command run
-                    taSelection.insertHtml(tagBegin + options + tagEnd, topNode);
+                    taSelection.insertHtml(tagBegin + text + tagEnd, topNode);
                 }else if(rangy.getSelection().getRangeAt(0).canSurroundContents()){
                     var node = angular.element(tagBegin + tagEnd)[0];
                     rangy.getSelection().getRangeAt(0).surroundContents(node);
@@ -3291,7 +3305,8 @@ angular.module('textAngular.taBind', ['textAngular.factories', 'textAngular.DOM'
                                             tagName !== 'h4' &&
                                             tagName !== 'h5' &&
                                             tagName !== 'h6' &&
-                                            tagName !== 'table'){
+                                            tagName !== 'table' &&
+                                            tagName !== 'span'){
                                             continue;
                                         }
                                     }

--- a/dist/textAngularSetup.js
+++ b/dist/textAngularSetup.js
@@ -254,6 +254,10 @@ angular.module('textAngularSetup', [])
         reLinkButton: {
             tooltip: "Relink"
         },
+        nameLinkButton: {
+            tooltip: "Text of the link",
+            dialogPromp: "Please enter a text from the URL"
+        },
         unLinkButton: {
             tooltip: "Unlink"
         },
@@ -406,6 +410,17 @@ angular.module('textAngularSetup', [])
                 editorScope.hidePopover();
             });
             buttonGroup.append(reLinkButton);
+            var nameLinkButton = angular.element('<button type="button" class="btn btn-default btn-sm btn-small" tabindex="-1" unselectable="on" title="' + taTranslations.editLink.nameLinkButton.tooltip + '"><i class="fa fa-comment-o icon-comment-alt"></i></button>');
+            nameLinkButton.on('click', function(event){
+                event.preventDefault();
+                var textLink = $window.prompt(taTranslations.editLink.nameLinkButton.dialogPromp, $element.html());
+                if(textLink && textLink !== ''){
+                    $element.html(textLink);
+                    editorScope.updateTaBindtaTextElement();
+                }
+                editorScope.hidePopover();
+            });
+            buttonGroup.append(nameLinkButton);
             var unLinkButton = angular.element('<button type="button" class="btn btn-default btn-sm btn-small" tabindex="-1" unselectable="on" title="' + taTranslations.editLink.unLinkButton.tooltip + '"><i class="fa fa-unlink icon-unlink"></i></button>');
             // directly before this click event is fired a digest is fired off whereby the reference to $element is orphaned off
             unLinkButton.on('click', function(event){

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -542,13 +542,27 @@ angular.module('textAngular.DOM', ['textAngular.factories'])
                 $target[0].focus();
                 return;
             }else if(command.toLowerCase() === 'createlink'){
+                var url,text;
+                if(Array.isArray(options)) {
+                    url = options[0];
+                    text = options[1];
+                    if (options[2]){
+                        text = '<i class="' + options[2] + '"></i> <span>' + text + '</span>';
+                    }
+                } else {
+                    url = options;
+                    text = options;
+                }
+
                 /* istanbul ignore next: firefox specific fix */
                 if (tagName === 'a') {
                     // already a link!!! we are just replacing it...
-                    taSelection.getSelectionElement().href = options;
+                    taSelection.getSelectionElement().href = url;
+                    taSelection.getSelectionElement().html = text;
+
                     return;
                 }
-                var tagBegin = '<a href="' + options + '" target="' +
+                var tagBegin = '<a href="' + url + '" target="' +
                         (defaultTagAttributes.a.target ? defaultTagAttributes.a.target : '') +
                         '">',
                     tagEnd = '</a>',
@@ -556,7 +570,7 @@ angular.module('textAngular.DOM', ['textAngular.factories'])
                 if(_selection.collapsed){
                     //console.log('collapsed');
                     // insert text at selection, then select then just let normal exec-command run
-                    taSelection.insertHtml(tagBegin + options + tagEnd, topNode);
+                    taSelection.insertHtml(tagBegin + text + tagEnd, topNode);
                 }else if(rangy.getSelection().getRangeAt(0).canSurroundContents()){
                     var node = angular.element(tagBegin + tagEnd)[0];
                     rangy.getSelection().getRangeAt(0).surroundContents(node);

--- a/src/textAngularSetup.js
+++ b/src/textAngularSetup.js
@@ -254,6 +254,10 @@ angular.module('textAngularSetup', [])
         reLinkButton: {
             tooltip: "Relink"
         },
+        nameLinkButton: {
+            tooltip: "Text of the link",
+            dialogPromp: "Please enter a text from the URL"
+        },
         unLinkButton: {
             tooltip: "Unlink"
         },
@@ -406,6 +410,17 @@ angular.module('textAngularSetup', [])
                 editorScope.hidePopover();
             });
             buttonGroup.append(reLinkButton);
+            var nameLinkButton = angular.element('<button type="button" class="btn btn-default btn-sm btn-small" tabindex="-1" unselectable="on" title="' + taTranslations.editLink.nameLinkButton.tooltip + '"><i class="fa fa-comment-o icon-comment-alt"></i></button>');
+            nameLinkButton.on('click', function(event){
+                event.preventDefault();
+                var textLink = $window.prompt(taTranslations.editLink.nameLinkButton.dialogPromp, $element.html());
+                if(textLink && textLink !== ''){
+                    $element.html(textLink);
+                    editorScope.updateTaBindtaTextElement();
+                }
+                editorScope.hidePopover();
+            });
+            buttonGroup.append(nameLinkButton);
             var unLinkButton = angular.element('<button type="button" class="btn btn-default btn-sm btn-small" tabindex="-1" unselectable="on" title="' + taTranslations.editLink.unLinkButton.tooltip + '"><i class="fa fa-unlink icon-unlink"></i></button>');
             // directly before this click event is fired a digest is fired off whereby the reference to $element is orphaned off
             unLinkButton.on('click', function(event){


### PR DESCRIPTION
- on selection we can edit the text link
- on taDropHandler when calling insertAction we can provide an array contaning the url and optionally a text to show instead of the url and css class names as string
example : insertAction('createLink', ['https://ex.edu.fr/files/document.odt', 'document.odt', 'fa fa-file-word-o fa-2x fa-lg' ], true)
and it will create the html tag :
``<a href="https://ex.edu.fr/files/document.odt" target="_blank"><i class="fa fa-file-word-o fa-2x fa-lg"></i> <span>document.odt</span></a>``