### PR TITLE
add --save in installation via bower

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To upgrade from version 1.2.2 or earlier you need to follow these steps:
 
 **Via Bower:**
 
-Run `bower install textAngular` from the command line.
+Run `bower install textAngular --save` from the command line.
 Include script tags similar to the following:
 ```html
 <link rel='stylesheet' href='/bower_components/textAngular/dist/textAngular.css'>


### PR DESCRIPTION
the users of this library is not only pro developer. I'm a newbie developer, and when I install this library via bower, I follow the guide in the readme. But after install it I realize that my `bower.json` is not re-written, so I try to install it with add `--save` in the end of the command. 

And I think if a pro developer wouldn't forget to add `--save` in the end of the command, but how about the newbie developer when read the readme and got error. So I add `--save` in the readme, Hope it will helpful in the future :smile: 