### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Include script tags similar to the following:
 
 Include script tag similar to the following: (For details on how this works see: [https://github.com/jsdelivr/jsdelivr#load-multiple-files-with-single-http-request](https://github.com/jsdelivr/jsdelivr#load-multiple-files-with-single-http-request))
 ```html
-<script src='http://cdn.jsdelivr.net/g/angular.textangular@1.5.0(textAngular-rangy.min.js+textAngular-sanitize.min.js+textAngular.min.js)'></script>
+<script src='https://cdn.jsdelivr.net/combine/npm/textangular@1.5.16/dist/textAngular-rangy.min.js,npm/textangular@1.5.16/dist/textAngular-sanitize.min.js,npm/textangular@1.5.16/dist/textAngular.min.js'></script>
 ```
 
 **Via Github**


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/textangular.

Feel free to ping me if you have any questions regarding this change.