### PR TITLE
fix (taBind): Fix broken HTML when list elements have an attribute.

### DIFF
--- a/src/taBind.js
+++ b/src/taBind.js
@@ -440,7 +440,7 @@ angular.module('textAngular.taBind', ['textAngular.factories', 'textAngular.DOM'
                         var _subnodes = listNode.childNodes;
                         tablevel++;
                         // tab out and add the <ul> or <ol> html piece
-                        _html += _repeat('\t', tablevel-1) + listNode.outerHTML.substring(0, 4);
+                        _html += _repeat('\t', tablevel-1) + listNode.outerHTML.substring(0, listNode.outerHTML.indexOf('>') + 1);
                         forEach(_subnodes, function (index, node) {
                             /* istanbul ignore next: browser catch */
                             var nodeName = node.nodeName.toLowerCase();

--- a/test/taBind/taBind.$formatters.spec.js
+++ b/test/taBind/taBind.$formatters.spec.js
@@ -26,6 +26,11 @@ describe('taBind.$formatters', function () {
             $rootScope.html = '<ul><li>Test Line 1</li><li>Test Line 2</li><li>Test Line 3</li></ul>';
             $rootScope.$digest();
             expect(element.val()).toBe('<ul>\n\t<li>Test Line 1</li>\n\t<li>Test Line 2</li>\n\t<li>Test Line 3</li>\n</ul>');
+        });        
+        it('handle lists with attributes', function(){
+            $rootScope.html = '<ul style="font-size: 10pt;"><li>Test Line 1</li><li>Test Line 2</li><li>Test Line 3</li></ul>';
+            $rootScope.$digest();
+            expect(element.val()).toBe('<ul style="font-size: 10pt;">\n\t<li>Test Line 1</li>\n\t<li>Test Line 2</li>\n\t<li>Test Line 3</li>\n</ul>');
         });
         it('handle nested lists', function(){
             $rootScope.html = '<ol><li>Test Line 1</li><ul><li>Nested Line 1</li><li>Nested Line 2</li></ul><li>Test Line 3</li></ol>';


### PR DESCRIPTION
Currently, the formatter in taBind will hard [cut off list elements at the 4th character](https://github.com/textAngular/textAngular/blob/master/src/taBind.js#L443).  This means that a `class` or `style` attribute can by typed and saved, but when the data is reloaded/bound any attributes are cut off and broken HTML is displayed.

This can be reproduced in the `taBind.$formatters.spec.js` tests for indenting lists.

Adding the following test to the current master branch will reproduce the failure:

```
        it('handle lists with attributes', function(){
            $rootScope.html = '<ul style="font-size: 10pt;"><li>Test Line 1</li><li>Test Line 2</li><li>Test Line 3</li></ul>';
            $rootScope.$digest();
            expect(element.val()).toBe('<ul style="font-size: 10pt;">\n\t<li>Test Line 1</li>\n\t<li>Test Line 2</li>\n\t<li>Test Line 3</li>\n</ul>');
        });
```

The test above and a fix are included in this PR.  Thank you!